### PR TITLE
feat: Add Microsoft.Extensions.AI implementations to Google.GenAI

### DIFF
--- a/DemoApp/Files/Properties/launchSettings.json
+++ b/DemoApp/Files/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Files": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:61145;http://localhost:61146"
+    }
+  }
+}

--- a/DemoApp/Files/packages.lock.json
+++ b/DemoApp/Files/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/GenerateContentSimpleText/Properties/launchSettings.json
+++ b/DemoApp/GenerateContentSimpleText/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "GenerateContentSimpleText": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55670;http://localhost:55671"
+    }
+  }
+}

--- a/DemoApp/GenerateContentSimpleText/packages.lock.json
+++ b/DemoApp/GenerateContentSimpleText/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/GenerateContentStreamSimpleText/Properties/launchSettings.json
+++ b/DemoApp/GenerateContentStreamSimpleText/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "GenerateContentStreamSimpleText": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59558;http://localhost:59559"
+    }
+  }
+}

--- a/DemoApp/GenerateContentStreamSimpleText/packages.lock.json
+++ b/DemoApp/GenerateContentStreamSimpleText/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/JsonParser/Properties/launchSettings.json
+++ b/DemoApp/JsonParser/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "JsonParser": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59555;http://localhost:59556"
+    }
+  }
+}

--- a/DemoApp/JsonParser/packages.lock.json
+++ b/DemoApp/JsonParser/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/LiveAudioToAudioRealtimeInput/Properties/launchSettings.json
+++ b/DemoApp/LiveAudioToAudioRealtimeInput/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "LiveAudioToAudioRealtimeInput": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59543;http://localhost:59544"
+    }
+  }
+}

--- a/DemoApp/LiveAudioToAudioRealtimeInput/packages.lock.json
+++ b/DemoApp/LiveAudioToAudioRealtimeInput/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/LiveTextToTextClientContent/Properties/launchSettings.json
+++ b/DemoApp/LiveTextToTextClientContent/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "LiveTextToTextClientContent": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:59538;http://localhost:59539"
+    }
+  }
+}

--- a/DemoApp/LiveTextToTextClientContent/packages.lock.json
+++ b/DemoApp/LiveTextToTextClientContent/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/DemoApp/LiveToolCall/Properties/launchSettings.json
+++ b/DemoApp/LiveToolCall/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "LiveToolCall": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:49803;http://localhost:49804"
+    }
+  }
+}

--- a/DemoApp/LiveToolCall/packages.lock.json
+++ b/DemoApp/LiveToolCall/packages.lock.json
@@ -28,6 +28,11 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -36,10 +41,17 @@
           "System.CodeDom": "7.0.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -51,6 +63,31 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,17 +9,13 @@
     </PackageVersion>
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="MimeTypes" Version="2.5.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
+    <PackageVersion Include="MimeTypes" Version="2.5.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.1.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
-    <PackageVersion Include="System.Net.WebSockets.Client" Version="4.3.2" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.1" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="TestServerSdk" Version="0.1.5" />

--- a/Google.GenAI.E2E.Tests/Google.GenAI.E2E.Tests.csproj
+++ b/Google.GenAI.E2E.Tests/Google.GenAI.E2E.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../ReleaseVersion.xml" />
   <PropertyGroup>
@@ -6,21 +6,20 @@
     <Nullable>enable</Nullable>
     <warningLevel>1</warningLevel>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Netstandard2_0Tests\**</DefaultItemExcludes>
+    <NoWarn>MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Netstandard2_0Tests\**" />
+
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MimeTypes">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="TestServerSdk" />
-    <ProjectReference Include="..\Google.GenAI\Google.GenAI.csproj">
-      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
-    </ProjectReference>
+    <ProjectReference Include="..\Google.GenAI\Google.GenAI.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />

--- a/Google.GenAI.E2E.Tests/Netstandard2_0Tests/Google.GenAI.E2E.Netstandard2_0Tests.csproj
+++ b/Google.GenAI.E2E.Tests/Netstandard2_0Tests/Google.GenAI.E2E.Netstandard2_0Tests.csproj
@@ -18,9 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MimeTypes">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="TestServerSdk" />
     <ProjectReference Include="..\..\Google.GenAI\Google.GenAI.csproj">

--- a/Google.GenAI.E2E.Tests/packages.lock.json
+++ b/Google.GenAI.E2E.Tests/packages.lock.json
@@ -31,12 +31,6 @@
           "System.Reflection.Metadata": "6.0.1"
         }
       },
-      "MimeTypes": {
-        "type": "Direct",
-        "requested": "[2.5.2, )",
-        "resolved": "2.5.2",
-        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
-      },
       "Moq": {
         "type": "Direct",
         "requested": "[4.20.70, )",
@@ -64,11 +58,12 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
         "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0"
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       },
       "TestServerSdk": {
@@ -219,6 +214,14 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -228,6 +231,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -257,8 +265,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
       },
       "YamlDotNet": {
         "type": "Transitive",
@@ -268,7 +276,9 @@
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -282,14 +292,20 @@
           "System.Management": "7.0.2"
         }
       },
-      "System.Collections.Immutable": {
+      "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Text.Json": "10.0.1"
         }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
       }
     }
   }

--- a/Google.GenAI.Tests/Google.GenAI.Tests.csproj
+++ b/Google.GenAI.Tests/Google.GenAI.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../ReleaseVersion.xml" />
   <PropertyGroup>
@@ -6,16 +6,18 @@
     <Nullable>enable</Nullable>
     <warningLevel>1</warningLevel>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Netstandard2_0Tests\**" />
+    
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <ProjectReference Include="..\Google.GenAI\Google.GenAI.csproj">
-      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
-    </ProjectReference>
+    <ProjectReference Include="..\Google.GenAI\Google.GenAI.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />

--- a/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
+++ b/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
@@ -1,0 +1,5077 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.GenAI.Types;
+using Microsoft.Extensions.AI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Google.GenAI.Tests;
+
+[TestClass]
+public class GoogleGenAIExtensionsTest
+{
+  [TestMethod]
+  public void AsIChatClient_NullModels_ThrowsArgumentNullException()
+  {
+    Models? models = null;
+    Assert.ThrowsException<ArgumentNullException>(() => models!.AsIChatClient("gemini-2.5-pro"));
+  }
+
+  [TestMethod]
+  public void AsIChatClient_NullClient_ThrowsArgumentNullException()
+  {
+    Client? client = null;
+    Assert.ThrowsException<ArgumentNullException>(() => client!.AsIChatClient("gemini-2.5-pro"));
+  }
+
+  [TestMethod]
+  public void AsIChatClient_ValidModels_ReturnsNonNull()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    
+    Assert.IsNotNull(models.AsIChatClient("gemini-2.5-pro"));
+  }
+
+  [TestMethod]
+  public void IChatClient_GetService_Models_ReturnsUnderlyingModels()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var client = models.AsIChatClient("gemini-2.5-pro");
+    
+    Assert.AreSame(models, client.GetService<Models>());
+    Assert.IsNull(client.GetService<Client>());
+  }
+
+  [TestMethod]
+  public void IChatClient_GetService_Client_ReturnsUnderlyingClient()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    var chatClient = client.AsIChatClient("gemini-2.5-pro");
+    Assert.AreSame(client, chatClient.GetService<Client>());
+    Assert.AreSame(client.Models, chatClient.GetService<Models>());
+  }
+
+  [TestMethod]
+  public void IChatClient_GetService_NullServiceType_ThrowsArgumentNullException()
+  {
+    var client = CreateChatClient("", "");
+    
+    Assert.ThrowsException<ArgumentNullException>(() => client.GetService(null!));
+  }
+
+  [TestMethod]
+  public void AsIImageGenerator_WithModels_ReturnsImageGenerator()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    
+    Assert.IsNotNull(models.AsIImageGenerator("imagen-3.0-generate-001"));
+  }
+
+  [TestMethod]
+  public void AsIImageGenerator_WithClient_ReturnsImageGenerator()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    
+    Assert.IsNotNull(client.AsIImageGenerator("imagen-3.0-generate-001"));
+  }
+
+  [TestMethod]
+  public void IImageGenerator_GetService_ImageGeneratorMetadata_ReturnsValidMetadata()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var imageGenerator = models.AsIImageGenerator("imagen-3.0-generate-001");
+    
+    var metadata = imageGenerator.GetService<ImageGeneratorMetadata>();
+    
+    Assert.IsNotNull(metadata);
+    Assert.IsNotNull(metadata.ProviderName);
+    Assert.AreEqual("gcp.gen_ai", metadata.ProviderName);
+    Assert.IsNotNull(metadata.ProviderUri);
+    Assert.IsInstanceOfType(metadata.ProviderUri, typeof(Uri));
+  }
+
+  [TestMethod]
+  public void IImageGenerator_GetService_Models_ReturnsUnderlyingModels()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var imageGenerator = models.AsIImageGenerator("imagen-3.0-generate-001");
+    
+    var retrievedModels = imageGenerator.GetService<Models>();
+    Assert.IsNotNull(retrievedModels);
+    Assert.AreSame(models, retrievedModels);
+
+    Assert.IsNull(imageGenerator.GetService<Client>());
+  }
+
+  [TestMethod]
+  public void IImageGenerator_GetService_Client_ReturnsUnderlyingClient()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    var imageGenerator = client.AsIImageGenerator("imagen-3.0-generate-001");
+    
+    Assert.AreSame(client, imageGenerator.GetService<Client>());
+    Assert.AreSame(client.Models, imageGenerator.GetService<Models>());
+  }
+
+  [TestMethod]
+  public void IImageGenerator_GetService_NullServiceType_ThrowsArgumentNullException()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var imageGenerator = models.AsIImageGenerator("imagen-3.0-generate-001");
+    
+    Assert.ThrowsException<ArgumentNullException>(() => imageGenerator.GetService(null!));
+  }
+
+  [TestMethod]
+  public void AsIImageGenerator_NullModels_ThrowsArgumentNullException()
+  {
+    Models? models = null;
+    Assert.ThrowsException<ArgumentNullException>(() => models!.AsIImageGenerator("imagen-3.0-generate-001"));
+  }
+
+  [TestMethod]
+  public void AsIImageGenerator_NullClient_ThrowsArgumentNullException()
+  {
+    Client? client = null;
+    Assert.ThrowsException<ArgumentNullException>(() => client!.AsIImageGenerator("imagen-3.0-generate-001"));
+  }
+
+  [TestMethod]
+  public void AsIEmbeddingGenerator_WithModels_ReturnsEmbeddingGenerator()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    
+    Assert.IsNotNull(models.AsIEmbeddingGenerator("text-embedding-004"));
+  }
+
+  [TestMethod]
+  public void AsIEmbeddingGenerator_WithClient_ReturnsEmbeddingGenerator()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    
+    Assert.IsNotNull(client.AsIEmbeddingGenerator("text-embedding-004"));
+  }
+
+  [TestMethod]
+  public void AsIEmbeddingGenerator_NullModels_ThrowsArgumentNullException()
+  {
+    Models? models = null;
+    Assert.ThrowsException<ArgumentNullException>(() => models!.AsIEmbeddingGenerator("text-embedding-004"));
+  }
+
+  [TestMethod]
+  public void AsIEmbeddingGenerator_NullClient_ThrowsArgumentNullException()
+  {
+    Client? client = null;
+    Assert.ThrowsException<ArgumentNullException>(() => client!.AsIEmbeddingGenerator("text-embedding-004"));
+  }
+
+  [TestMethod]
+  public void IEmbeddingGenerator_GetService_Metadata_ReturnsValidMetadata()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var embeddingGenerator = models.AsIEmbeddingGenerator("text-embedding-004", 768);
+    
+    var metadata = embeddingGenerator.GetService<EmbeddingGeneratorMetadata>();
+    
+    Assert.IsNotNull(metadata);
+    Assert.AreEqual("gcp.gen_ai", metadata.ProviderName);
+    Assert.AreEqual(new Uri("https://generativelanguage.googleapis.com/"), metadata.ProviderUri);
+    Assert.AreEqual("text-embedding-004", metadata.DefaultModelId);
+    Assert.AreEqual(768, metadata.DefaultModelDimensions);
+  }
+
+  [TestMethod]
+  public void IEmbeddingGenerator_GetService_Models_ReturnsUnderlyingModels()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var embeddingGenerator = models.AsIEmbeddingGenerator("text-embedding-004");
+    
+    Assert.AreSame(models, embeddingGenerator.GetService<Models>());
+    Assert.IsNull(embeddingGenerator.GetService<Client>());
+  }
+
+  [TestMethod]
+  public void IEmbeddingGenerator_GetService_Client_ReturnsUnderlyingClient()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    var embeddingGenerator = client.AsIEmbeddingGenerator("text-embedding-004");
+    
+    Assert.AreSame(client, embeddingGenerator.GetService<Client>());
+    Assert.AreSame(client.Models, embeddingGenerator.GetService<Models>());
+  }
+
+  [TestMethod]
+  public void IEmbeddingGenerator_GetService_NullServiceType_ThrowsArgumentNullException()
+  {
+    var models = new Models(new MockApiClient("", ""));
+    var embeddingGenerator = models.AsIEmbeddingGenerator("text-embedding-004");
+    
+    Assert.ThrowsException<ArgumentNullException>(() => embeddingGenerator.GetService(null!));
+  }
+
+  [TestMethod]
+  public async Task IEmbeddingGenerator_BasicRequest()
+  {
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator = CreateEmbeddingGenerator("""
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello embeddings"
+                }
+              ]
+            },
+            "model": "models/text-embedding-004",
+            "outputDimensionality": 128
+          }
+        ]
+      }
+      """, """
+      {
+        "embeddings": [
+          {
+            "values": [0.1, 0.2, 0.3]
+          }
+        ]
+      }
+      """, defaultDimensions: 128);
+
+    var response = await embeddingGenerator.GenerateAsync(["Hello embeddings"]);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Count);
+    var embedding = response[0];
+    CollectionAssert.AreEqual(new[] { 0.1f, 0.2f, 0.3f }, embedding.Vector.ToArray());
+    Assert.AreEqual("text-embedding-004", embedding.ModelId);
+    Assert.IsNull(response.Usage); // Gemini API (Mldev) does not return statistics
+  }
+
+  [TestMethod]
+  public async Task IEmbeddingGenerator_WithOptionsOverrides()
+  {
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator = CreateEmbeddingGenerator("""
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Trip plan intro"
+                }
+              ]
+            },
+            "taskType": "RETRIEVAL_DOCUMENT",
+            "title": "Trip plan",
+            "model": "models/text-embedding-005",
+            "outputDimensionality": 64
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Trip plan details"
+                }
+              ]
+            },
+            "taskType": "RETRIEVAL_DOCUMENT",
+            "title": "Trip plan",
+            "model": "models/text-embedding-005",
+            "outputDimensionality": 64
+          }
+        ]
+      }
+      """, """
+      {
+        "embeddings": [
+          {
+            "values": [0.5, 0.25, -0.5, 0.75]
+          },
+          {
+            "values": [-0.1, 0.9, 0.4, -0.2]
+          }
+        ]
+      }
+      """);
+
+    bool factoryCalled = false;
+    EmbeddingGenerationOptions options = new()
+    {
+      ModelId = "text-embedding-005",
+      Dimensions = 64,
+      RawRepresentationFactory = _ =>
+      {
+        factoryCalled = true;
+        return new EmbedContentConfig
+        {
+          TaskType = "RETRIEVAL_DOCUMENT",
+          Title = "Trip plan"
+        };
+      }
+    };
+
+    var response = await embeddingGenerator.GenerateAsync(["Trip plan intro", "Trip plan details"], options);
+    
+    Assert.IsTrue(factoryCalled);
+    Assert.AreEqual(2, response.Count);
+    CollectionAssert.AreEqual(new[] { 0.5f, 0.25f, -0.5f, 0.75f }, response[0].Vector.ToArray());
+    CollectionAssert.AreEqual(new[] { -0.1f, 0.9f, 0.4f, -0.2f }, response[1].Vector.ToArray());
+    Assert.AreEqual("text-embedding-005", response[0].ModelId);
+    Assert.AreEqual("text-embedding-005", response[1].ModelId);
+    Assert.IsNull(response.Usage); // Gemini API (Mldev) does not return statistics
+  }
+
+  [TestMethod]
+  public async Task IEmbeddingGenerator_RawRepresentationFactoryNotOverriddenByOptions()
+  {
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator = CreateEmbeddingGenerator("""
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Custom config"
+                }
+              ]
+            },
+            "taskType": "SEMANTIC_SIMILARITY",
+            "model": "models/text-embedding-004",
+            "outputDimensionality": 42
+          }
+        ]
+      }
+      """, """
+      {
+        "embeddings": [
+          {
+            "values": [1.0, 2.0]
+          }
+        ]
+      }
+      """
+    );
+
+    EmbeddingGenerationOptions options = new()
+    {
+      Dimensions = 256,
+      RawRepresentationFactory = _ => new EmbedContentConfig
+      {
+        TaskType = "SEMANTIC_SIMILARITY",
+        OutputDimensionality = 42
+      }
+    };
+
+    var response = await embeddingGenerator.GenerateAsync(["Custom config"], options);
+    
+    Assert.AreEqual(1, response.Count);
+    CollectionAssert.AreEqual(new[] { 1f, 2f }, response[0].Vector.ToArray());
+    Assert.IsNull(response.Usage);
+  }
+
+  [TestMethod]
+  public async Task IEmbeddingGenerator_UsageMetadataValidation()
+  {
+    // Test usage metadata when statistics are returned (Vertex API)
+    IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator = CreateEmbeddingGenerator("""
+      {
+        "requests": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "First text"
+                }
+              ]
+            },
+            "model": "models/text-embedding-004"
+          },
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Second text"
+                }
+              ]
+            },
+            "model": "models/text-embedding-004"
+          }
+        ]
+      }
+      """, """
+      {
+        "embeddings": [
+          {
+            "values": [0.1, 0.2, 0.3],
+            "statistics": {
+              "tokenCount": 5,
+              "truncated": false
+            }
+          },
+          {
+            "values": [0.4, 0.5, 0.6],
+            "statistics": {
+              "tokenCount": 7,
+              "truncated": false
+            }
+          }
+        ]
+      }
+      """);
+
+    var response = await embeddingGenerator.GenerateAsync(["First text", "Second text"]);
+
+    Assert.IsNotNull(response);
+    Assert.AreEqual(2, response.Count);
+    CollectionAssert.AreEqual(new[] { 0.1f, 0.2f, 0.3f }, response[0].Vector.ToArray());
+    CollectionAssert.AreEqual(new[] { 0.4f, 0.5f, 0.6f }, response[1].Vector.ToArray());
+    Assert.AreEqual("text-embedding-004", response[0].ModelId);
+    Assert.AreEqual("text-embedding-004", response[1].ModelId);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(12, response.Usage.InputTokenCount);
+    Assert.IsNull(response.Usage.CachedInputTokenCount);
+    Assert.IsNull(response.Usage.OutputTokenCount);
+    Assert.IsNull(response.Usage.ReasoningTokenCount);
+    Assert.AreEqual(12, response.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IEmbeddingGenerator_GenerateAsync_NullValues_ThrowsArgumentNullException()
+  {
+    var embeddingGenerator = CreateEmbeddingGenerator("{}", "{}");
+    
+    await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => embeddingGenerator.GenerateAsync(null!));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_BasicRequestResponse()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello, world!"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello there! The classic first words of any new program.\n\nHow can I help you today?"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 20,
+          "totalTokenCount": 1024,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 5
+            }
+          ],
+          "thoughtsTokenCount": 999
+        },
+        "modelVersion": "gemini-2.5-pro",
+        "responseId": "UTQBaY2BNLXg_uMP9Y_W8Q8"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Hello, world!");
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.AreEqual("Hello there! The classic first words of any new program.\n\nHow can I help you today?", response.Messages[0].Text);
+    Assert.AreEqual(1, response.Messages[0].Contents.Count);
+    Assert.IsInstanceOfType(response.Messages[0].Contents[0], typeof(TextContent));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(5, response.Usage.InputTokenCount);
+    Assert.AreEqual(20, response.Usage.OutputTokenCount);
+    Assert.AreEqual(1024, response.Usage.TotalTokenCount);
+    Assert.AreEqual("gemini-2.5-pro", response.ModelId);
+    Assert.IsNotNull(response.RawRepresentation);
+    Assert.AreEqual("UTQBaY2BNLXg_uMP9Y_W8Q8", ((GenerateContentResponse)response.RawRepresentation).ResponseId);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_MultipleMessagesConversation()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What is 2+2?"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "4"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "And what is 3+3?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "6"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 18,
+          "candidatesTokenCount": 1,
+          "totalTokenCount": 19
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "What is 2+2?"),
+      new(ChatRole.Assistant, "4"),
+      new(ChatRole.User, "And what is 3+3?")
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual("6", response.Messages[0].Text);
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithSystemInstructions()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What should I do?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {},
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are a helpful pirate. Always respond like a pirate."
+            }
+          ]
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Ahoy there, matey!  What be troublin' ye?  Tell ol' Captain Helpful what needs doin', and I'll steer ye in the right direction, or me name ain't... well, it ain't really Captain Helpful, but ye get the idea!  Spit it out, scallywag! \n"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 24,
+          "candidatesTokenCount": 62,
+          "totalTokenCount": 86
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.System, "You are a helpful pirate. Always respond like a pirate."),
+      new(ChatRole.User, "What should I do?")
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("matey") || response.Messages[0].Text.Contains("Ahoy"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithTemperatureAndTopP()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Say hello"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "temperature": 0.1,
+          "topP": 0.95
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello! 👋 \n"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 4,
+          "candidatesTokenCount": 5,
+          "totalTokenCount": 9
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      Temperature = 0.1f,
+      TopP = 0.95f
+    };
+
+    var response = await client.GetResponseAsync("Say hello", options);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithMaxTokens()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Write a long story"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "maxOutputTokens": 10
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Once upon a time, in a land far, far away"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "MAX_TOKENS",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 6,
+          "candidatesTokenCount": 10,
+          "totalTokenCount": 16
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      MaxOutputTokens = 10
+    };
+
+    var response = await client.GetResponseAsync("Write a long story", options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(ChatFinishReason.Length, response.FinishReason);
+    Assert.AreEqual(10, response.Usage?.OutputTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithStopSequences()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Count: 1, 2, 3, 4, 5"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "stopSequences": ["4"]
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Okay, you've started counting: 1, 2, 3,"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 15,
+          "candidatesTokenCount": 13,
+          "totalTokenCount": 28
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      StopSequences = ["4"]
+    };
+
+    var response = await client.GetResponseAsync("Count: 1, 2, 3, 4, 5", options);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(response.Messages[0].Text.Contains('4'));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithTopK()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Pick a number"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "topK": 40
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "7 \n"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 8
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      TopK = 40
+    };
+
+    var response = await client.GetResponseAsync("Pick a number", options);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_MultipleContentParts()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "First part. "
+              },
+              {
+                "text": "Second part."
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Okay, I received your message in two parts: \"First part. \" and \"Second part.\"\n\nWhat would you like me to do with this information? \n"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 10,
+          "candidatesTokenCount": 33,
+          "totalTokenCount": 43
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage message = new(ChatRole.User, [
+      new TextContent("First part. "),
+      new TextContent("Second part.")
+    ]);
+
+    var response = await client.GetResponseAsync([message]);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("two parts") || response.Messages[0].Text.Contains("First") && response.Messages[0].Text.Contains("Second"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_EmptyMessage()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": ""
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello! How can I help you today? \n"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 2,
+          "candidatesTokenCount": 10,
+          "totalTokenCount": 12
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("");
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ResponseWithMultipleTextParts()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Tell me about AI"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "AI, or Artificial Intelligence, refers to the simulation of human intelligence in machines"
+                },
+                {
+                  "text": " that are programmed to think and learn."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 6,
+          "candidatesTokenCount": 25,
+          "totalTokenCount": 31
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Tell me about AI");
+    
+    Assert.IsNotNull(response);
+    var message = response.Messages[0];
+    Assert.IsTrue(message.Contents.Count >= 1);
+    var combinedText = string.Join("", message.Contents.OfType<TextContent>().Select(c => c.Text));
+    Assert.IsTrue(combinedText.Contains("Artificial Intelligence") || combinedText.Contains("AI"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_UsageMetadataValidation()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Test"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Test received."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 2,
+          "candidatesTokenCount": 4,
+          "totalTokenCount": 6
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Test");
+    
+    Assert.IsNotNull(response);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(2, response.Usage.InputTokenCount);
+    Assert.AreEqual(4, response.Usage.OutputTokenCount);
+    Assert.AreEqual(6, response.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ModelVersionInResponse()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hi"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hi there!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 2,
+          "candidatesTokenCount": 4,
+          "totalTokenCount": 6
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Hi");
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual("gemini-2.5-pro", response.ModelId);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithFunctionTool()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What's the weather?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets the current weather",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["location"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "functionCall": {
+                    "name": "get_weather",
+                    "args": {
+                      "location": "San Francisco"
+                    }
+                  }
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 10,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 18
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      Tools = [AIFunctionFactory.Create((string location) => "sunny", "get_weather", "Gets the current weather")]
+    };
+
+    var response = await client.GetResponseAsync("What's the weather?", options);
+    
+    Assert.IsNotNull(response);
+    var functionCall = response.Messages[0].Contents.OfType<FunctionCallContent>().FirstOrDefault();
+    Assert.IsNotNull(functionCall);
+    Assert.AreEqual("get_weather", functionCall.Name);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithFunctionResult()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "response": {
+                    "result": "sunny"
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Based on the weather data, it's sunny!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 12,
+          "candidatesTokenCount": 10,
+          "totalTokenCount": 22
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage message = new(ChatRole.User, [
+      new FunctionResultContent("get_weather", "sunny")
+    ]);
+
+    var response = await client.GetResponseAsync([message]);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("sunny"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ResponseWithImageData()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What's in this image?"
+              },
+              {
+                "inlineData": {
+                  "mimeType": "image/png",
+                  "data": "iVBORw0K"
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I see a simple image."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 15,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 23
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    byte[] imageBytes = Convert.FromBase64String("iVBORw0K");
+    ChatMessage message = new(ChatRole.User, [
+      new TextContent("What's in this image?"),
+      new DataContent(imageBytes, "image/png")
+    ]);
+
+    var response = await client.GetResponseAsync([message]);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ResponseWithImageUri()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Describe this"
+              },
+              {
+                "fileData": {
+                  "mimeType": "image/jpeg",
+                  "fileUri": "https://example.com/image.jpg"
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "The image shows an example."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 12,
+          "candidatesTokenCount": 7,
+          "totalTokenCount": 19
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage message = new(ChatRole.User, [
+      new TextContent("Describe this"),
+      new UriContent(new Uri("https://example.com/image.jpg"), "image/jpeg")
+    ]);
+
+    var response = await client.GetResponseAsync([message]);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithJsonResponseFormat()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Return JSON"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "responseMimeType": "application/json"
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "{\"result\": \"success\"}"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 8,
+          "candidatesTokenCount": 6,
+          "totalTokenCount": 14
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      ResponseFormat = ChatResponseFormat.Json
+    };
+
+    var response = await client.GetResponseAsync("Return JSON", options);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("result"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_LongConversationHistory()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hi"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "Hello"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "How are you?"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "I'm good"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Great"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Glad to hear it!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 20,
+          "candidatesTokenCount": 6,
+          "totalTokenCount": 26
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "Hi"),
+      new(ChatRole.Assistant, "Hello"),
+      new(ChatRole.User, "How are you?"),
+      new(ChatRole.Assistant, "I'm good"),
+      new(ChatRole.User, "Great")
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FinishReasonMaxTokens()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Write a story"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "maxOutputTokens": 5
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Once upon a time"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "MAX_TOKENS",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 5,
+          "totalTokenCount": 10
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      MaxOutputTokens = 5
+    };
+
+    var response = await client.GetResponseAsync("Write a story", options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(ChatFinishReason.Length, response.FinishReason);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_MultipleSystemMessages()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Tell me something"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are helpful. You are concise."
+            }
+          ]
+        },
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Sure!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 15,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 18
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.System, [new TextContent("You are helpful. "), new TextContent("You are concise.")]),
+      new(ChatRole.User, "Tell me something")
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithAllGenerationOptions()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Test"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "temperature": 0.5,
+          "topP": 0.9,
+          "topK": 20,
+          "maxOutputTokens": 100,
+          "stopSequences": ["END"]
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Response text"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 8
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      Temperature = 0.5f,
+      TopP = 0.9f,
+      TopK = 20,
+      MaxOutputTokens = 100,
+      StopSequences = ["END"]
+    };
+
+    var response = await client.GetResponseAsync("Test", options);
+    
+    Assert.IsNotNull(response);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_MultiTurnConversationWithRepeatedFunctionCalls()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Check the stock price for GOOGL"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_stock_price",
+                  "name": "get_stock_price",
+                  "args": {
+                    "symbol": "GOOGL"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_stock_price",
+                  "name": "get_stock_price",
+                  "response": {
+                    "result": {
+                      "symbol": "GOOGL",
+                      "price": 142.50
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "GOOGL is currently trading at $142.50."
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Now check MSFT"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_stock_price",
+                  "name": "get_stock_price",
+                  "args": {
+                    "symbol": "MSFT"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_stock_price",
+                  "name": "get_stock_price",
+                  "response": {
+                    "result": {
+                      "symbol": "MSFT",
+                      "price": 378.91
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets current stock price",
+                "name": "get_stock_price",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "symbol": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["symbol"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Microsoft (MSFT) is trading at $378.91, which is significantly higher than Google's $142.50."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 85,
+          "candidatesTokenCount": 22,
+          "totalTokenCount": 107
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    AIFunction stockFunc = AIFunctionFactory.Create(
+      (string symbol) => symbol == "GOOGL" 
+        ? new { symbol = "GOOGL", price = 142.50 }
+        : new { symbol = "MSFT", price = 378.91 },
+      "get_stock_price",
+      "Gets current stock price");
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "Check the stock price for GOOGL"),
+      new(ChatRole.Assistant, [new FunctionCallContent("get_stock_price", "get_stock_price", new Dictionary<string, object?> { ["symbol"] = "GOOGL" })]),
+      new(ChatRole.User, [new FunctionResultContent("get_stock_price", new { symbol = "GOOGL", price = 142.50 })]),
+      new(ChatRole.Assistant, "GOOGL is currently trading at $142.50."),
+      new(ChatRole.User, "Now check MSFT"),
+      new(ChatRole.Assistant, [new FunctionCallContent("get_stock_price", "get_stock_price", new Dictionary<string, object?> { ["symbol"] = "MSFT" })]),
+      new(ChatRole.User, [new FunctionResultContent("get_stock_price", new { symbol = "MSFT", price = 378.91 })])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [stockFunc]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.IsTrue(response.Messages[0].Text.Contains("MSFT") || response.Messages[0].Text.Contains("Microsoft"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("378.91"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(85, response.Usage.InputTokenCount);
+    Assert.AreEqual(22, response.Usage.OutputTokenCount);
+    Assert.AreEqual(107, response.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ComplexMultiToolConversationWithErrorHandling()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "I need to schedule a meeting and send an email about it"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "schedule_meeting",
+                  "name": "schedule_meeting",
+                  "args": {
+                    "title": "Team Sync",
+                    "date": "2025-11-01",
+                    "duration": 60
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "schedule_meeting",
+                  "name": "schedule_meeting",
+                  "response": {
+                    "result": {
+                      "meetingId": "MTG123",
+                      "status": "scheduled"
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "send_email",
+                  "name": "send_email",
+                  "args": {
+                    "to": "team@example.com",
+                    "subject": "Team Sync Scheduled",
+                    "body": "Meeting scheduled for Nov 1, 2025"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "send_email",
+                  "name": "send_email",
+                  "response": {
+                    "result": {
+                      "messageId": "MSG456",
+                      "sent": true
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Schedules a meeting",
+                "name": "schedule_meeting",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "title": {"type": "string"},
+                    "date": {"type": "string"},
+                    "duration": {"type": "integer"}
+                  },
+                  "required": ["title", "date", "duration"]
+                }
+              },
+              {
+                "description": "Sends an email",
+                "name": "send_email",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "to": {"type": "string"},
+                    "subject": {"type": "string"},
+                    "body": {"type": "string"}
+                  },
+                  "required": ["to", "subject", "body"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Done! I've scheduled your Team Sync meeting for November 1st, 2025 (meeting ID: MTG123) and sent an email notification to the team (message ID: MSG456)."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 120,
+          "candidatesTokenCount": 35,
+          "totalTokenCount": 155
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "I need to schedule a meeting and send an email about it"),
+      new(ChatRole.Assistant, [new FunctionCallContent("schedule_meeting", "schedule_meeting", new Dictionary<string, object?> { ["title"] = "Team Sync", ["date"] = "2025-11-01", ["duration"] = 60 })]),
+      new(ChatRole.User, [new FunctionResultContent("schedule_meeting", new { meetingId = "MTG123", status = "scheduled" })]),
+      new(ChatRole.Assistant, [new FunctionCallContent("send_email", "send_email", new Dictionary<string, object?> { ["to"] = "team@example.com", ["subject"] = "Team Sync Scheduled", ["body"] = "Meeting scheduled for Nov 1, 2025" })]),
+      new(ChatRole.User, [new FunctionResultContent("send_email", new { messageId = "MSG456", sent = true })])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [
+        AIFunctionFactory.Create((string title, string date, int duration) => new { meetingId = "MTG123", status = "scheduled" }, "schedule_meeting", "Schedules a meeting"),
+        AIFunctionFactory.Create((string to, string subject, string body) => new { messageId = "MSG456", sent = true }, "send_email", "Sends an email")
+      ]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.AreEqual(1, response.Messages[0].Contents.Count);
+    Assert.IsInstanceOfType(response.Messages[0].Contents[0], typeof(TextContent));
+    Assert.IsTrue(response.Messages[0].Text.Contains("MTG123"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("MSG456"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("scheduled") || response.Messages[0].Text.Contains("sent"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(120, response.Usage.InputTokenCount);
+    Assert.AreEqual(35, response.Usage.OutputTokenCount);
+    Assert.IsNotNull(response.RawRepresentation);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_VeryLongConversationWithMixedContent()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello, I need help planning a trip"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "I'd be happy to help you plan your trip! Where would you like to go?"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Paris, France"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "Excellent choice! When are you planning to travel?"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Next month"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "search_flights",
+                  "name": "search_flights",
+                  "args": {
+                    "destination": "Paris",
+                    "month": "December"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "search_flights",
+                  "name": "search_flights",
+                  "response": {
+                    "result": {
+                      "flights": [
+                        {"airline": "Air France", "price": 750},
+                        {"airline": "Delta", "price": 820}
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "I found flights for you. Air France has flights for $750 and Delta for $820. Which would you prefer?"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Air France please"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "book_flight",
+                  "name": "book_flight",
+                  "args": {
+                    "airline": "Air France",
+                    "price": 750
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "book_flight",
+                  "name": "book_flight",
+                  "response": {
+                    "result": {
+                      "confirmationNumber": "AF789XYZ",
+                      "status": "confirmed"
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "Great! Your flight is booked. Confirmation: AF789XYZ. Would you like me to help find a hotel?"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Yes, something near the Eiffel Tower"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "search_hotels",
+                  "name": "search_hotels",
+                  "args": {
+                    "location": "Eiffel Tower",
+                    "city": "Paris"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "search_hotels",
+                  "name": "search_hotels",
+                  "response": {
+                    "result": {
+                      "hotels": [
+                        {"name": "Hotel Eiffel Seine", "price": 200},
+                        {"name": "Pullman Paris Tour Eiffel", "price": 350}
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Searches for flights",
+                "name": "search_flights",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {"type": "string"},
+                    "month": {"type": "string"}
+                  },
+                  "required": ["destination", "month"]
+                }
+              },
+              {
+                "description": "Books a flight",
+                "name": "book_flight",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "airline": {"type": "string"},
+                    "price": {"type": "number"}
+                  },
+                  "required": ["airline", "price"]
+                }
+              },
+              {
+                "description": "Searches for hotels",
+                "name": "search_hotels",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {"type": "string"},
+                    "city": {"type": "string"}
+                  },
+                  "required": ["location", "city"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I found two great options near the Eiffel Tower: Hotel Eiffel Seine at $200/night and Pullman Paris Tour Eiffel at $350/night. Which one interests you?"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 250,
+          "candidatesTokenCount": 38,
+          "totalTokenCount": 288
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "Hello, I need help planning a trip"),
+      new(ChatRole.Assistant, "I'd be happy to help you plan your trip! Where would you like to go?"),
+      new(ChatRole.User, "Paris, France"),
+      new(ChatRole.Assistant, "Excellent choice! When are you planning to travel?"),
+      new(ChatRole.User, "Next month"),
+      new(ChatRole.Assistant, [new FunctionCallContent("search_flights", "search_flights", new Dictionary<string, object?> { ["destination"] = "Paris", ["month"] = "December" })]),
+      new(ChatRole.User, [new FunctionResultContent("search_flights", new { flights = new[] { new { airline = "Air France", price = 750 }, new { airline = "Delta", price = 820 } } })]),
+      new(ChatRole.Assistant, "I found flights for you. Air France has flights for $750 and Delta for $820. Which would you prefer?"),
+      new(ChatRole.User, "Air France please"),
+      new(ChatRole.Assistant, [new FunctionCallContent("book_flight", "book_flight", new Dictionary<string, object?> { ["airline"] = "Air France", ["price"] = 750 })]),
+      new(ChatRole.User, [new FunctionResultContent("book_flight", new { confirmationNumber = "AF789XYZ", status = "confirmed" })]),
+      new(ChatRole.Assistant, "Great! Your flight is booked. Confirmation: AF789XYZ. Would you like me to help find a hotel?"),
+      new(ChatRole.User, "Yes, something near the Eiffel Tower"),
+      new(ChatRole.Assistant, [new FunctionCallContent("search_hotels", "search_hotels", new Dictionary<string, object?> { ["location"] = "Eiffel Tower", ["city"] = "Paris" })]),
+      new(ChatRole.User, [new FunctionResultContent("search_hotels", new { hotels = new[] { new { name = "Hotel Eiffel Seine", price = 200 }, new { name = "Pullman Paris Tour Eiffel", price = 350 } } })])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [
+        AIFunctionFactory.Create((string destination, string month) => new { flights = new[] { new { airline = "Air France", price = 750 } } }, "search_flights", "Searches for flights"),
+        AIFunctionFactory.Create((string airline, double price) => new { confirmationNumber = "AF789XYZ", status = "confirmed" }, "book_flight", "Books a flight"),
+        AIFunctionFactory.Create((string location, string city) => new { hotels = new[] { new { name = "Hotel Eiffel Seine", price = 200 } } }, "search_hotels", "Searches for hotels")
+      ]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.IsTrue(response.Messages[0].Text.Contains("Hotel Eiffel Seine") || response.Messages[0].Text.Contains("Pullman"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("200") || response.Messages[0].Text.Contains("350"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(250, response.Usage.InputTokenCount);
+    Assert.AreEqual(38, response.Usage.OutputTokenCount);
+    Assert.AreEqual(288, response.Usage.TotalTokenCount);
+    Assert.AreEqual("gemini-2.5-pro", response.ModelId);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ParallelFunctionCallsInConversation()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Compare the weather in New York, London, and Tokyo"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "args": {
+                    "city": "New York"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              },
+              {
+                "functionCall": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "args": {
+                    "city": "London"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              },
+              {
+                "functionCall": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "args": {
+                    "city": "Tokyo"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "response": {
+                    "result": {
+                      "city": "New York",
+                      "temp": 45,
+                      "condition": "cloudy"
+                    }
+                  }
+                }
+              },
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "response": {
+                    "result": {
+                      "city": "London",
+                      "temp": 50,
+                      "condition": "rainy"
+                    }
+                  }
+                }
+              },
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "response": {
+                    "result": {
+                      "city": "Tokyo",
+                      "temp": 65,
+                      "condition": "sunny"
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets weather for a city",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "city": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["city"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Here's the weather comparison:\n- New York: 45°F and cloudy\n- London: 50°F and rainy\n- Tokyo: 65°F and sunny\n\nTokyo has the warmest and best weather of the three cities!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 75,
+          "candidatesTokenCount": 48,
+          "totalTokenCount": 123
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "Compare the weather in New York, London, and Tokyo"),
+      new(ChatRole.Assistant, [
+        new FunctionCallContent("get_weather", "get_weather", new Dictionary<string, object?> { ["city"] = "New York" }),
+        new FunctionCallContent("get_weather", "get_weather", new Dictionary<string, object?> { ["city"] = "London" }),
+        new FunctionCallContent("get_weather", "get_weather", new Dictionary<string, object?> { ["city"] = "Tokyo" })
+      ]),
+      new(ChatRole.User, [
+        new FunctionResultContent("get_weather", new { city = "New York", temp = 45, condition = "cloudy" }),
+        new FunctionResultContent("get_weather", new { city = "London", temp = 50, condition = "rainy" }),
+        new FunctionResultContent("get_weather", new { city = "Tokyo", temp = 65, condition = "sunny" })
+      ])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [AIFunctionFactory.Create((string city) => 
+        city == "New York" ? new { city = "New York", temp = 45, condition = "cloudy" } :
+        city == "London" ? new { city = "London", temp = 50, condition = "rainy" } :
+        new { city = "Tokyo", temp = 65, condition = "sunny" },
+        "get_weather", "Gets weather for a city")]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.IsTrue(response.Messages[0].Text.Contains("New York"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("London"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("Tokyo"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("45") || response.Messages[0].Text.Contains("50") || response.Messages[0].Text.Contains("65"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(75, response.Usage.InputTokenCount);
+    Assert.AreEqual(48, response.Usage.OutputTokenCount);
+    Assert.AreEqual(123, response.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithTextReasoningContent()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Think step by step about this math problem: What is 15 * 23?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "responseModalities": ["TEXT"],
+          "thinkingConfig": {
+            "includeThoughts": true,
+            "thinkingBudget": -1
+          }
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "thought": true,
+                  "text": "Let me break this down:\n15 * 23 = 15 * (20 + 3)\n= (15 * 20) + (15 * 3)\n= 300 + 45\n= 345"
+                },
+                {
+                  "text": "The answer is 345."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 18,
+          "candidatesTokenCount": 45,
+          "totalTokenCount": 63,
+          "thoughtsTokenCount": 35
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      RawRepresentationFactory = (_) => new GenerateContentConfig
+      {
+        ResponseModalities = ["TEXT"],
+        ThinkingConfig = new ThinkingConfig { IncludeThoughts = true, ThinkingBudget = -1 }
+      }
+    };
+
+    var response = await client.GetResponseAsync("Think step by step about this math problem: What is 15 * 23?", options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.AreEqual(2, response.Messages[0].Contents.Count);
+    
+    // First part should be reasoning
+    var reasoningContent = response.Messages[0].Contents[0] as TextReasoningContent;
+    Assert.IsNotNull(reasoningContent, "First content should be TextReasoningContent");
+    Assert.IsTrue(reasoningContent.Text.Contains("break this down") || reasoningContent.Text.Contains("15 * 20"));
+    
+    // Second part should be final answer
+    var textContent = response.Messages[0].Contents[1] as TextContent;
+    Assert.IsNotNull(textContent, "Second content should be TextContent");
+    Assert.IsTrue(textContent.Text.Contains("345"));
+    
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(18, response.Usage.InputTokenCount);
+    Assert.IsNull(response.Usage.CachedInputTokenCount);
+    Assert.AreEqual(45, response.Usage.OutputTokenCount);
+    Assert.AreEqual(35, response.Usage.ReasoningTokenCount);
+    Assert.AreEqual(63, response.Usage.TotalTokenCount);
+    Assert.IsNull(response.Usage.AdditionalCounts);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_WithThinkingConfigProtected()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Solve this: 7^3"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "thinkingConfig": {
+            "includeThoughts": true
+          }
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "thought": true,
+                  "thoughtSignature": "dGhpbmtpbmcgc2lnbmF0dXJlIGRhdGE="
+                },
+                {
+                  "text": "7^3 = 343"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 8,
+          "candidatesTokenCount": 15,
+          "totalTokenCount": 23,
+          "thoughtsTokenCount": 10
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      RawRepresentationFactory = (_) => new GenerateContentConfig
+      {
+        ThinkingConfig = new ThinkingConfig 
+        { 
+          IncludeThoughts = true
+        }
+      }
+    };
+
+    var response = await client.GetResponseAsync("Solve this: 7^3", options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    // When thought is protected (only thoughtSignature, no text), it may be merged with the answer
+    Assert.IsTrue(response.Messages[0].Contents.Count >= 1);
+    
+    var textContent = response.Messages[0].Contents.OfType<TextContent>().FirstOrDefault();
+    Assert.IsNotNull(textContent, "Should have text content with answer");
+    Assert.IsTrue(textContent.Text.Contains("343"));
+    
+    // Check if we got reasoning content with protected data
+    var reasoningContent = response.Messages[0].Contents.OfType<TextReasoningContent>().FirstOrDefault();
+    if (reasoningContent != null)
+    {
+      Assert.IsNotNull(reasoningContent.ProtectedData);
+      Assert.AreEqual("dGhpbmtpbmcgc2lnbmF0dXJlIGRhdGE=", reasoningContent.ProtectedData);
+    }
+    
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(8, response.Usage.InputTokenCount);
+    Assert.AreEqual(15, response.Usage.OutputTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ComplexConversationWithFunctionCalls()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What's the weather in Seattle and how does it compare to San Francisco?"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "args": {
+                    "location": "Seattle"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              },
+              {
+                "functionCall": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "args": {
+                    "location": "San Francisco"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "response": {
+                    "result": {
+                      "temperature": 55,
+                      "condition": "rainy"
+                    }
+                  }
+                }
+              },
+              {
+                "functionResponse": {
+                  "id": "get_weather",
+                  "name": "get_weather",
+                  "response": {
+                    "result": {
+                      "temperature": 72,
+                      "condition": "sunny"
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets weather for a location",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["location"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Seattle is currently 55°F and rainy, while San Francisco is warmer at 72°F and sunny. San Francisco has much better weather today - it's 17 degrees warmer and not raining!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 45,
+          "candidatesTokenCount": 38,
+          "totalTokenCount": 83
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    AIFunction weatherFunc = AIFunctionFactory.Create(
+      (string location) => location == "Seattle" 
+        ? new { temperature = 55, condition = "rainy" }
+        : new { temperature = 72, condition = "sunny" },
+      "get_weather",
+      "Gets weather for a location");
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "What's the weather in Seattle and how does it compare to San Francisco?"),
+      new(ChatRole.Assistant, [
+        new FunctionCallContent("get_weather", "get_weather", new Dictionary<string, object?> { ["location"] = "Seattle" }),
+        new FunctionCallContent("get_weather", "get_weather", new Dictionary<string, object?> { ["location"] = "San Francisco" })
+      ]),
+      new(ChatRole.User, [
+        new FunctionResultContent("get_weather", new { temperature = 55, condition = "rainy" }),
+        new FunctionResultContent("get_weather", new { temperature = 72, condition = "sunny" })
+      ])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [weatherFunc]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.IsTrue(response.Messages[0].Text.Contains("Seattle"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("San Francisco"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("55") || response.Messages[0].Text.Contains("72"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(45, response.Usage.InputTokenCount);
+    Assert.AreEqual(38, response.Usage.OutputTokenCount);
+    Assert.AreEqual(83, response.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ExtendedConversationWithMultipleTools()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Book me a flight to Paris"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "search_flights",
+                  "name": "search_flights",
+                  "args": {
+                    "destination": "Paris",
+                    "date": "2025-11-01"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "search_flights",
+                  "name": "search_flights",
+                  "response": {
+                    "result": {
+                      "flights": [
+                        {"airline": "Air France", "price": 850, "duration": "11h"},
+                        {"airline": "United", "price": 920, "duration": "12h"}
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "I found 2 flights for you. Air France for $850 (11h) and United for $920 (12h). Which would you prefer?"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "Book the Air France flight"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "book_flight",
+                  "name": "book_flight",
+                  "args": {
+                    "airline": "Air France",
+                    "price": 850
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "book_flight",
+                  "name": "book_flight",
+                  "response": {
+                    "result": {
+                      "confirmationNumber": "AF12345",
+                      "status": "confirmed"
+                    }
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Searches for flights",
+                "name": "search_flights",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {"type": "string"},
+                    "date": {"type": "string"}
+                  },
+                  "required": ["destination", "date"]
+                }
+              },
+              {
+                "description": "Books a flight",
+                "name": "book_flight",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "airline": {"type": "string"},
+                    "price": {"type": "number"}
+                  },
+                  "required": ["airline", "price"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Perfect! I've booked your Air France flight to Paris. Your confirmation number is AF12345. Have a great trip!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 120,
+          "candidatesTokenCount": 25,
+          "totalTokenCount": 145
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.User, "Book me a flight to Paris"),
+      new(ChatRole.Assistant, [new FunctionCallContent("search_flights", "search_flights", new Dictionary<string, object?> { ["destination"] = "Paris", ["date"] = "2025-11-01" })]),
+      new(ChatRole.User, [new FunctionResultContent("search_flights", new { flights = new[] { new { airline = "Air France", price = 850, duration = "11h" }, new { airline = "United", price = 920, duration = "12h" } } })]),
+      new(ChatRole.Assistant, "I found 2 flights for you. Air France for $850 (11h) and United for $920 (12h). Which would you prefer?"),
+      new(ChatRole.User, "Book the Air France flight"),
+      new(ChatRole.Assistant, [new FunctionCallContent("book_flight", "book_flight", new Dictionary<string, object?> { ["airline"] = "Air France", ["price"] = 850 })]),
+      new(ChatRole.User, [new FunctionResultContent("book_flight", new { confirmationNumber = "AF12345", status = "confirmed" })])
+    ];
+
+    ChatOptions options = new()
+    {
+      Tools = [
+        AIFunctionFactory.Create((string destination, string? date) => new { flights = new[] { new { airline = "Air France", price = 850 } } }, "search_flights", "Searches for flights"),
+        AIFunctionFactory.Create((string airline, double price) => new { confirmationNumber = "AF12345", status = "confirmed" }, "book_flight", "Books a flight")
+      ]
+    };
+
+    var response = await client.GetResponseAsync(messages, options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.AreEqual(1, response.Messages[0].Contents.Count);
+    Assert.IsInstanceOfType(response.Messages[0].Contents[0], typeof(TextContent));
+    Assert.IsTrue(response.Messages[0].Text.Contains("AF12345"));
+    Assert.IsTrue(response.Messages[0].Text.Contains("Air France") || response.Messages[0].Text.Contains("booked"));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(120, response.Usage.InputTokenCount);
+    Assert.AreEqual(25, response.Usage.OutputTokenCount);
+    Assert.AreEqual(145, response.Usage.TotalTokenCount);
+    Assert.IsNotNull(response.RawRepresentation);
+    Assert.IsInstanceOfType(response.RawRepresentation, typeof(GenerateContentResponse));
+    Assert.AreEqual("gemini-2.5-pro", response.ModelId);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_RawRepresentationFactoryWithCustomConfig()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Test custom config"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "temperature": 0.3,
+          "candidateCount": 1,
+          "responseModalities": ["TEXT"]
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Response with custom configuration."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 7,
+          "totalTokenCount": 12
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatOptions options = new()
+    {
+      Temperature = 0.3f,
+      RawRepresentationFactory = (_) => new GenerateContentConfig
+      {
+        CandidateCount = 1,
+        ResponseModalities = ["TEXT"]
+      }
+    };
+
+    var response = await client.GetResponseAsync("Test custom config", options);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, response.Messages[0].Role);
+    Assert.IsFalse(string.IsNullOrEmpty(response.Messages[0].Text));
+    Assert.AreEqual(ChatFinishReason.Stop, response.FinishReason);
+    Assert.IsNotNull(response.Usage);
+    Assert.AreEqual(5, response.Usage.InputTokenCount);
+    Assert.AreEqual(7, response.Usage.OutputTokenCount);
+    Assert.IsNotNull(response.RawRepresentation);
+    
+    var rawResponse = response.RawRepresentation as GenerateContentResponse;
+    Assert.IsNotNull(rawResponse);
+    Assert.AreEqual(1, rawResponse.Candidates?.Count);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingWithThinkingAndFunctionCall()
+  {
+    var weatherFunc = AIFunctionFactory.Create(
+      (string location) => $"72°F and sunny in {location}",
+      "get_weather",
+      "Gets the weather for a location");
+
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Think carefully about why someone in Paris might want to know the weather, then tell me the weather there."
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets the weather for a location",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "location"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {
+          "thinkingConfig": {
+            "includeThoughts": true,
+            "thinkingBudget": -1
+          }
+        }
+      }
+      """, """
+      data: {"candidates": [{"content": {"parts": [{"text": "Understanding the context","thought": true}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 60,"totalTokenCount": 65,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 60}],"thoughtsTokenCount": 5},"modelVersion": "gemini-2.5-pro"}
+      data: {"candidates": [{"content": {"parts": [{"text": "Of course! Someone in Paris might want to know the weather to decide whether to","thoughtSignature": "CiIB0e2Kb3a4gkvo"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 60,"candidatesTokenCount": 15,"totalTokenCount": 80,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 60}],"thoughtsTokenCount": 5},"modelVersion": "gemini-2.5-pro"}
+      data: {"candidates": [{"content": {"parts": [{"text": " stroll along the Seine, visit an outdoor market, or perhaps opt for a cozy day in a museum."}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 60,"candidatesTokenCount": 35,"totalTokenCount": 100,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 60}],"thoughtsTokenCount": 5},"modelVersion": "gemini-2.5-pro"}
+      data: {"candidates": [{"content": {"parts": [{"text": " Let me check the weather for you."}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 60,"candidatesTokenCount": 41,"totalTokenCount": 106,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 60}],"thoughtsTokenCount": 5},"modelVersion": "gemini-2.5-pro"}
+      data: {"candidates": [{"content": {"parts": [{"functionCall": {"name": "get_weather","args": {"location": "Paris"}}}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 60,"candidatesTokenCount": 47,"totalTokenCount": 112,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 60}],"thoughtsTokenCount": 5},"modelVersion": "gemini-2.5-pro"}
+      """);
+
+    ChatOptions options = new()
+    {
+      Tools = [weatherFunc],
+      RawRepresentationFactory = (_) => new GenerateContentConfig
+      {
+        ThinkingConfig = new ThinkingConfig { IncludeThoughts = true, ThinkingBudget = -1 }
+      }
+    };
+
+    // Use a message list instead of a string
+    List<ChatMessage> messageHistory =
+    [
+      new(ChatRole.User, "Think carefully about why someone in Paris might want to know the weather, then tell me the weather there.")
+    ];
+
+    List<ChatResponseUpdate> updates = [];
+    await foreach (var update in client.GetStreamingResponseAsync(messageHistory, options))
+    {
+      updates.Add(update);
+    }
+
+    // Validate the updates
+    Assert.AreEqual(5, updates.Count);
+    
+    // First update: Thinking content with "thought": true
+    Assert.IsTrue(updates[0].Contents.Any(c => c is TextReasoningContent));
+    var thinkingContent1 = updates[0].Contents.OfType<TextReasoningContent>().First();
+    Assert.IsTrue(thinkingContent1.Text.Contains("context"));
+    
+    // Second update: Text with thoughtSignature
+    Assert.IsTrue(updates[1].Contents.Any(c => c is TextContent));
+    var textContent1 = updates[1].Contents.OfType<TextContent>().First();
+    Assert.IsTrue(textContent1.Text.Contains("Paris"));
+    
+    // Third update: More text
+    Assert.IsTrue(updates[2].Contents.Any(c => c is TextContent));
+    var textContent2 = updates[2].Contents.OfType<TextContent>().First();
+    Assert.IsTrue(textContent2.Text.Contains("Seine") || textContent2.Text.Contains("museum"));
+    
+    // Fourth update: More text
+    Assert.IsTrue(updates[3].Contents.Any(c => c is TextContent));
+    var textContent3 = updates[3].Contents.OfType<TextContent>().First();
+    Assert.IsTrue(textContent3.Text.Contains("weather"));
+    
+    // Fifth update: Function call
+    Assert.IsTrue(updates[4].Contents.Any(c => c is FunctionCallContent));
+    var functionCall = updates[4].Contents.OfType<FunctionCallContent>().First();
+    Assert.AreEqual("get_weather", functionCall.Name);
+    Assert.IsTrue(functionCall.Arguments?.ContainsKey("location"));
+    Assert.AreEqual("Paris", functionCall.Arguments?["location"]?.ToString());
+    Assert.AreEqual(ChatFinishReason.Stop, updates[4].FinishReason);
+    
+    // Validate final response
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual(1, finalResponse.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    
+    // Should have thinking, text, and function call
+    Assert.IsTrue(finalResponse.Messages[0].Contents.Count >= 3);
+    Assert.IsTrue(finalResponse.Messages[0].Contents.Any(c => c is TextReasoningContent));
+    Assert.IsTrue(finalResponse.Messages[0].Contents.Any(c => c is TextContent));
+    Assert.IsTrue(finalResponse.Messages[0].Contents.Any(c => c is FunctionCallContent));
+    
+    // Validate usage metadata
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.IsTrue(finalResponse.Usage.InputTokenCount > 0);
+    Assert.IsTrue(finalResponse.Usage.OutputTokenCount > 0);
+    Assert.IsTrue(finalResponse.Usage.TotalTokenCount > 0);
+    
+    // Add the updates to the message history
+    messageHistory.AddRange(updates.ToChatResponse().Messages);
+    
+    // Verify message history now has user message + assistant message with function call
+    Assert.AreEqual(2, messageHistory.Count);
+    Assert.AreEqual(ChatRole.User, messageHistory[0].Role);
+    Assert.AreEqual(ChatRole.Assistant, messageHistory[1].Role);
+    Assert.IsTrue(messageHistory[1].Contents.Any(c => c is FunctionCallContent));
+    
+    // Add function result
+    var functionCallFromHistory = messageHistory[1].Contents.OfType<FunctionCallContent>().First();
+    var result = await weatherFunc.InvokeAsync(new(functionCallFromHistory.Arguments));
+    messageHistory.Add(new ChatMessage(ChatRole.Tool, [new FunctionResultContent(functionCallFromHistory.CallId, result)]));
+    
+    // Verify we have 3 messages now
+    Assert.AreEqual(3, messageHistory.Count);
+    Assert.AreEqual(ChatRole.Tool, messageHistory[2].Role);
+    
+    // Now make a second streaming call with the full conversation history
+    // This client has the expected request/response for the second turn
+    // Note: The expected request needs to match the actual serialization from the message history,
+    // which includes thought markers and uses "user" role for function results
+    var client2 = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Think carefully about why someone in Paris might want to know the weather, then tell me the weather there."
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "thought": true,
+                "text": "Understanding the context"
+              },
+              {
+                "thoughtSignature": "CiIB0e2Kb3a4gkvo",
+                "text": "Of course! Someone in Paris might want to know the weather to decide whether to"
+              },
+              {
+                "text": " stroll along the Seine, visit an outdoor market, or perhaps opt for a cozy day in a museum. Let me check the weather for you."
+              },
+              {
+                "functionCall": {
+                  "name": "get_weather",
+                  "args": {
+                    "location": "Paris"
+                  }
+                }
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "",
+                  "name": "get_weather",
+                  "response": {
+                    "result": "72\u00B0F and sunny in Paris"
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets the weather for a location",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "location"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {
+          "thinkingConfig": {
+            "includeThoughts": true,
+            "thinkingBudget": -1
+          }
+        }
+      }
+      """, """
+      data: {"candidates": [{"content": {"parts": [{"text": "The weather in Paris"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 145,"candidatesTokenCount": 4,"totalTokenCount": 149,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 145}]},"modelVersion": "gemini-2.5-pro"}
+      data: {"candidates": [{"content": {"parts": [{"text": " is 72°F and sunny."}],"role": "model"},"finishReason": "STOP","index": 0}],"usageMetadata": {"promptTokenCount": 145,"candidatesTokenCount": 13,"totalTokenCount": 158,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 145}]},"modelVersion": "gemini-2.5-pro"}
+      """);
+    
+    List<ChatResponseUpdate> updates2 = [];
+    await foreach (var update in client2.GetStreamingResponseAsync(messageHistory, options))
+    {
+      updates2.Add(update);
+    }
+    
+    // Validate the second response
+    Assert.AreEqual(2, updates2.Count);
+    
+    // First update: Text content
+    Assert.IsTrue(updates2[0].Contents.Any(c => c is TextContent));
+    var text1 = updates2[0].Contents.OfType<TextContent>().First();
+    Assert.IsTrue(text1.Text.Contains("weather") || text1.Text.Contains("Paris"));
+    
+    // Second update: More text with finish reason
+    Assert.IsTrue(updates2[1].Contents.Any(c => c is TextContent));
+    var text2 = updates2[1].Contents.OfType<TextContent>().First();
+    Assert.IsTrue(text2.Text.Contains("72") || text2.Text.Contains("sunny"));
+    Assert.AreEqual(ChatFinishReason.Stop, updates2[1].FinishReason);
+    
+    // Validate the final aggregated response
+    var finalResponse2 = updates2.ToChatResponse();
+    Assert.IsNotNull(finalResponse2);
+    Assert.AreEqual(1, finalResponse2.Messages.Count);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse2.Messages[0].Role);
+    
+    // Should have text content
+    Assert.IsTrue(finalResponse2.Messages[0].Contents.Any(c => c is TextContent));
+    
+    // Validate usage
+    Assert.IsNotNull(finalResponse2.Usage);
+    Assert.IsTrue(finalResponse2.Usage.InputTokenCount > 0);
+    Assert.IsTrue(finalResponse2.Usage.OutputTokenCount > 0);
+    Assert.IsTrue(finalResponse2.Usage.TotalTokenCount > 0);
+    
+    // Add the second response to history and verify final state
+    messageHistory.AddRange(finalResponse2.Messages);
+    Assert.AreEqual(4, messageHistory.Count);
+    Assert.AreEqual(ChatRole.User, messageHistory[0].Role);
+    Assert.AreEqual(ChatRole.Assistant, messageHistory[1].Role);
+    Assert.AreEqual(ChatRole.Tool, messageHistory[2].Role);
+    Assert.AreEqual(ChatRole.Assistant, messageHistory[3].Role);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingBasicResponse()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Say hello"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": " there"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 4,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 7
+        }
+      }
+      """);
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("Say hello"))
+    {
+      updates.Add(update);
+      Assert.IsNotNull(update);
+      Assert.AreEqual(ChatRole.Assistant, update.Role);
+    }
+
+    Assert.AreEqual(3, updates.Count);
+    Assert.AreEqual("Hello", updates[0].Text);
+    Assert.AreEqual(" there", updates[1].Text);
+    Assert.AreEqual("!", updates[2].Text);
+    Assert.AreEqual(ChatFinishReason.Stop, updates[2].FinishReason);
+    Assert.IsNotNull(updates[2].Contents);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("Hello there!", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(4, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(3, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(7, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingWithFunctionCall()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What is the weather in Paris?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "tools": [
+          {
+            "functionDeclarations": [
+              {
+                "description": "Gets weather",
+                "name": "get_weather",
+                "parametersJsonSchema": {
+                  "type": "object",
+                  "properties": {
+                    "city": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["city"]
+                }
+              }
+            ]
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "functionCall": {
+                    "name": "get_weather",
+                    "args": {
+                      "city": "Paris"
+                    }
+                  }
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 15,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 23
+        }
+      }
+      """);
+
+    AIFunction weatherFunc = AIFunctionFactory.Create(
+      (string city) => new { city, temp = 72, condition = "sunny" },
+      "get_weather",
+      "Gets weather");
+
+    ChatOptions options = new() { Tools = [weatherFunc] };
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("What is the weather in Paris?", options))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(1, updates.Count);
+    Assert.IsNotNull(updates[0].Contents);
+    Assert.IsInstanceOfType(updates[0].Contents[0], typeof(FunctionCallContent));
+    
+    var functionCall = (FunctionCallContent)updates[0].Contents[0];
+    Assert.AreEqual("get_weather", functionCall.Name);
+    Assert.IsNotNull(functionCall.Arguments);
+    Assert.IsTrue(functionCall.Arguments.ContainsKey("city"));
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.AreEqual(1, finalResponse.Messages[0].Contents.Count);
+    Assert.IsInstanceOfType(finalResponse.Messages[0].Contents[0], typeof(FunctionCallContent));
+    var finalFunctionCall = (FunctionCallContent)finalResponse.Messages[0].Contents[0];
+    Assert.AreEqual("get_weather", finalFunctionCall.Name);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(15, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(8, finalResponse.Usage.OutputTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingMultipleChunks()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Count to five"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "1"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": ", 2"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": ", 3"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": ", 4"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": ", 5"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 9,
+          "totalTokenCount": 14
+        }
+      }
+      """);
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("Count to five"))
+    {
+      updates.Add(update);
+      Assert.IsNotNull(update);
+    }
+
+    Assert.AreEqual(5, updates.Count);
+    Assert.AreEqual("1", updates[0].Text);
+    Assert.AreEqual(", 2", updates[1].Text);
+    Assert.AreEqual(", 3", updates[2].Text);
+    Assert.AreEqual(", 4", updates[3].Text);
+    Assert.AreEqual(", 5", updates[4].Text);
+    Assert.AreEqual(ChatFinishReason.Stop, updates[4].FinishReason);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("1, 2, 3, 4, 5", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(5, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(9, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(14, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingWithSystemMessage()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hi"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "Be brief"
+            }
+          ]
+        },
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hello"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 6,
+          "candidatesTokenCount": 2,
+          "totalTokenCount": 8
+        }
+      }
+      """);
+
+    ChatMessage[] messages = [
+      new(ChatRole.System, "Be brief"),
+      new(ChatRole.User, "Hi")
+    ];
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync(messages))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(1, updates.Count);
+    Assert.AreEqual("Hello", updates[0].Text);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("Hello", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(6, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(2, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(8, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingWithConversationHistory()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hi"
+              }
+            ],
+            "role": "user"
+          },
+          {
+            "parts": [
+              {
+                "text": "Hello"
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "text": "How are you?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I'm doing"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": " well, thanks!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 12,
+          "candidatesTokenCount": 6,
+          "totalTokenCount": 18
+        }
+      }
+      """);
+
+    ChatMessage[] messages = [
+      new(ChatRole.User, "Hi"),
+      new(ChatRole.Assistant, "Hello"),
+      new(ChatRole.User, "How are you?")
+    ];
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync(messages))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(2, updates.Count);
+    Assert.AreEqual("I'm doing", updates[0].Text);
+    Assert.AreEqual(" well, thanks!", updates[1].Text);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("I'm doing well, thanks!", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(12, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(6, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(18, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingFinishReasonMaxTokens()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Write a story"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "maxOutputTokens": 3
+        }
+      }
+      """, """
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Once upon"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": " a"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "MAX_TOKENS",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 5,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 8
+        }
+      }
+      """);
+
+    ChatOptions options = new() { MaxOutputTokens = 3 };
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("Write a story", options))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(2, updates.Count);
+    Assert.AreEqual(ChatFinishReason.Length, updates[1].FinishReason);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("Once upon a", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Length, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(5, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(3, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(8, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingWithTemperature()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Be creative"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {
+          "temperature": 0.5
+        }
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Let me think creatively!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 4,
+          "candidatesTokenCount": 6,
+          "totalTokenCount": 10
+        }
+      }
+      """);
+
+    ChatOptions options = new() { Temperature = 0.5f };
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("Be creative", options))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(1, updates.Count);
+    
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("Let me think creatively!", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(4, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(6, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(10, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_StreamingEmptyInitialChunks()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": ""
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Hi"
+                }
+              ],
+              "role": "model"
+            },
+            "index": 0
+          }
+        ]
+      }
+      data: {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": " there"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 2,
+          "candidatesTokenCount": 3,
+          "totalTokenCount": 5
+        }
+      }
+      """);
+
+    List<ChatResponseUpdate> updates = [];;
+    await foreach (var update in client.GetStreamingResponseAsync("Hello"))
+    {
+      updates.Add(update);
+    }
+
+    Assert.AreEqual(3, updates.Count);
+    Assert.AreEqual("", updates[0].Text);
+    Assert.AreEqual("Hi", updates[1].Text);
+    Assert.AreEqual(" there", updates[2].Text);
+
+    var finalResponse = updates.ToChatResponse();
+    Assert.IsNotNull(finalResponse);
+    Assert.AreEqual("Hi there", finalResponse.Messages[0].Text);
+    Assert.AreEqual(ChatRole.Assistant, finalResponse.Messages[0].Role);
+    Assert.AreEqual(ChatFinishReason.Stop, finalResponse.FinishReason);
+    Assert.IsNotNull(finalResponse.Usage);
+    Assert.AreEqual(2, finalResponse.Usage.InputTokenCount);
+    Assert.AreEqual(3, finalResponse.Usage.OutputTokenCount);
+    Assert.AreEqual(5, finalResponse.Usage.TotalTokenCount);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionResultWithDataContent()
+  {
+    // Test that DataContent with supported media types are sent as inline data in function response
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "capture_screenshot",
+                  "name": "capture_screenshot"
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "parts": [
+                    {
+                      "inlineData": {
+                        "mimeType": "image/png",
+                        "data": "iVBORw0K"
+                      }
+                    }
+                  ],
+                  "id": "capture_screenshot",
+                  "name": "capture_screenshot"
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I can see the screenshot shows a simple image."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 50,
+          "candidatesTokenCount": 12,
+          "totalTokenCount": 62
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    byte[] imageBytes = Convert.FromBase64String("iVBORw0K");
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("capture_screenshot", "capture_screenshot")]),
+      new(ChatRole.User, [new FunctionResultContent("capture_screenshot", new DataContent(imageBytes, "image/png"))])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("screenshot"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionResultWithUriContent()
+  {
+    // Test that UriContent with supported media types are sent as file data in function response
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_document",
+                  "name": "get_document"
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "parts": [
+                    {
+                      "fileData": {
+                        "fileUri": "https://example.com/document.pdf",
+                        "mimeType": "application/pdf"
+                      }
+                    }
+                  ],
+                  "id": "get_document",
+                  "name": "get_document"
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I analyzed the PDF document."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 45,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 53
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("get_document", "get_document")]),
+      new(ChatRole.User, [new FunctionResultContent("get_document", new UriContent(new Uri("https://example.com/document.pdf"), "application/pdf"))])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("PDF"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionResultWithMultipleContentItems()
+  {
+    // Test that IEnumerable<AIContent> function results are properly handled
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_data",
+                  "name": "get_data"
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "parts": [
+                    {
+                      "inlineData": {
+                        "mimeType": "image/jpeg",
+                        "data": "iVBORw0K"
+                      }
+                    }
+                  ],
+                  "id": "get_data",
+                  "name": "get_data",
+                  "response": {
+                    "result": [
+                      {
+                        "$type": "text",
+                        "Text": "Additional text data",
+                        "Annotations": null,
+                        "AdditionalProperties": null
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I received both the image and text data."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 55,
+          "candidatesTokenCount": 10,
+          "totalTokenCount": 65
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    byte[] imageBytes = Convert.FromBase64String("iVBORw0K");
+    List<AIContent> results =
+    [
+      new DataContent(imageBytes, "image/jpeg"),
+      new TextContent("Additional text data")
+    ];
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("get_data", "get_data")]),
+      new(ChatRole.User, [new FunctionResultContent("get_data", results)])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("image") || response.Messages[0].Text.Contains("text"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ResponseWithCodeExecution()
+  {
+    // Test parsing of ExecutableCode and CodeExecutionResult from response
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Calculate 42 * 17"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "executableCode": {
+                    "language": "PYTHON",
+                    "code": "result = 42 * 17\nprint(result)"
+                  }
+                },
+                {
+                  "codeExecutionResult": {
+                    "outcome": "OUTCOME_OK",
+                    "output": "714"
+                  }
+                },
+                {
+                  "text": "The result of 42 * 17 is 714."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 8,
+          "candidatesTokenCount": 25,
+          "totalTokenCount": 33
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Calculate 42 * 17");
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+    
+    var contents = response.Messages[0].Contents;
+    Assert.AreEqual(3, contents.Count);
+    
+    // First content should be CodeInterpreterToolCallContent
+    Assert.IsInstanceOfType(contents[0], typeof(CodeInterpreterToolCallContent));
+    var codeCall = (CodeInterpreterToolCallContent)contents[0];
+    Assert.IsNotNull(codeCall.Inputs);
+    Assert.AreEqual(1, codeCall.Inputs.Count);
+    Assert.IsInstanceOfType(codeCall.Inputs[0], typeof(DataContent));
+    var codeContent = (DataContent)codeCall.Inputs[0];
+    Assert.AreEqual("text/x-python", codeContent.MediaType);
+    string code = Encoding.UTF8.GetString(codeContent.Data.Span);
+    Assert.IsTrue(code.Contains("42 * 17"));
+    
+    // Second content should be CodeInterpreterToolResultContent
+    Assert.IsInstanceOfType(contents[1], typeof(CodeInterpreterToolResultContent));
+    var codeResult = (CodeInterpreterToolResultContent)contents[1];
+    Assert.IsNotNull(codeResult.Outputs);
+    Assert.AreEqual(1, codeResult.Outputs.Count);
+    Assert.IsInstanceOfType(codeResult.Outputs[0], typeof(TextContent));
+    Assert.AreEqual("714", ((TextContent)codeResult.Outputs[0]).Text);
+    
+    // Third content should be TextContent
+    Assert.IsInstanceOfType(contents[2], typeof(TextContent));
+    Assert.IsTrue(((TextContent)contents[2]).Text.Contains("714"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_ResponseWithCodeExecutionError()
+  {
+    // Test parsing of CodeExecutionResult with error outcome
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Run some code that fails"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "executableCode": {
+                    "language": "PYTHON",
+                    "code": "print(undefined_variable)"
+                  }
+                },
+                {
+                  "codeExecutionResult": {
+                    "outcome": "OUTCOME_FAILED",
+                    "output": "NameError: name 'undefined_variable' is not defined"
+                  }
+                },
+                {
+                  "text": "The code failed with an error."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 10,
+          "candidatesTokenCount": 30,
+          "totalTokenCount": 40
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("Run some code that fails");
+    
+    Assert.IsNotNull(response);
+    var contents = response.Messages[0].Contents;
+    Assert.AreEqual(3, contents.Count);
+    
+    // Second content should be CodeInterpreterToolResultContent with ErrorContent
+    Assert.IsInstanceOfType(contents[1], typeof(CodeInterpreterToolResultContent));
+    var codeResult = (CodeInterpreterToolResultContent)contents[1];
+    Assert.IsNotNull(codeResult.Outputs);
+    Assert.AreEqual(1, codeResult.Outputs.Count);
+    Assert.IsInstanceOfType(codeResult.Outputs[0], typeof(ErrorContent));
+    var errorContent = (ErrorContent)codeResult.Outputs[0];
+    Assert.IsTrue(errorContent.Message.Contains("NameError"));
+    Assert.AreEqual("OUTCOME_FAILED", errorContent.ErrorCode);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_RawRepresentationPartPassthrough()
+  {
+    // Test that AIContent with Part as RawRepresentation is passed through directly
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello from raw part"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Response received!"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 6,
+          "candidatesTokenCount": 4,
+          "totalTokenCount": 10
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    // Create content with Part as RawRepresentation
+    var part = new Part { Text = "Hello from raw part" };
+    var content = new AIContent { RawRepresentation = part };
+    
+    ChatMessage message = new(ChatRole.User, [content]);
+
+    var response = await client.GetResponseAsync([message]);
+    
+    Assert.IsNotNull(response);
+    Assert.AreEqual("Response received!", response.Messages[0].Text);
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionCallWithSkipThoughtValidation()
+  {
+    // Test that FunctionCallContent sent back includes thought signature for skip validation
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "test_func",
+                  "name": "test_func",
+                  "args": {
+                    "param": "value"
+                  }
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "test_func",
+                  "name": "test_func",
+                  "response": {
+                    "result": "success"
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Function executed successfully."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 20,
+          "candidatesTokenCount": 6,
+          "totalTokenCount": 26
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("test_func", "test_func", new Dictionary<string, object?> { ["param"] = "value" })]),
+      new(ChatRole.User, [new FunctionResultContent("test_func", "success")])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("success"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionResultWithTextContent()
+  {
+    // Test that TextContent as function result is sent with text in response
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_text",
+                  "name": "get_text"
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "id": "get_text",
+                  "name": "get_text",
+                  "response": {
+                    "result": "Hello world"
+                  }
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "The text says: Hello world"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 18,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 26
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("get_text", "get_text")]),
+      new(ChatRole.User, [new FunctionResultContent("get_text", new TextContent("Hello world"))])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("Hello world"));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_FunctionResultWithDataContentDisplayName()
+  {
+    // Test that DataContent with Name is sent with displayName in the blob
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "functionCall": {
+                  "id": "get_file",
+                  "name": "get_file"
+                },
+                "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+              }
+            ],
+            "role": "model"
+          },
+          {
+            "parts": [
+              {
+                "functionResponse": {
+                  "parts": [
+                    {
+                      "inlineData": {
+                        "mimeType": "text/plain",
+                        "data": "SGVsbG8gV29ybGQ=",
+                        "displayName": "readme.txt"
+                      }
+                    }
+                  ],
+                  "id": "get_file",
+                  "name": "get_file"
+                }
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "I received the file readme.txt"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 25,
+          "candidatesTokenCount": 8,
+          "totalTokenCount": 33
+        },
+        "modelVersion": "gemini-2.5-pro"
+      }
+      """);
+
+    byte[] fileBytes = Encoding.UTF8.GetBytes("Hello World");
+    var dataContent = new DataContent(fileBytes, "text/plain") { Name = "readme.txt" };
+
+    ChatMessage[] messages =
+    [
+      new(ChatRole.Assistant, [new FunctionCallContent("get_file", "get_file")]),
+      new(ChatRole.User, [new FunctionResultContent("get_file", dataContent)])
+    ];
+
+    var response = await client.GetResponseAsync(messages);
+    
+    Assert.IsNotNull(response);
+    Assert.IsTrue(response.Messages[0].Text.Contains("readme.txt"));
+  }
+
+  [TestMethod]
+  public async Task IImageGeneration_BasicRequest()
+  {
+    IImageGenerator imageGenerator = CreateImageGenerator("""
+      {
+        "instances": [
+          {
+            "prompt": "A red apple"
+          }
+        ],
+        "parameters": {
+          "sampleCount": 1
+        }
+      }
+      """, """
+      {
+        "predictions": [
+          {
+            "bytesBase64Encoded": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            "mimeType": "image/png"
+          }
+        ]
+      }
+      """);
+
+    var response = await imageGenerator.GenerateImagesAsync("A red apple");
+
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Contents.Count);
+    Assert.IsInstanceOfType(response.Contents[0], typeof(DataContent));
+    
+    var dataContent = (DataContent)response.Contents[0];
+    Assert.IsNotNull(dataContent.Data);
+    Assert.IsTrue(dataContent.Data.Length > 0);
+    Assert.AreEqual("image/png", dataContent.MediaType);
+  }
+
+  [TestMethod]
+  public async Task IImageGeneration_WithOptions()
+  {
+    IImageGenerator imageGenerator = CreateImageGenerator("""
+      {
+        "instances": [
+          {
+            "prompt": "A blue car"
+          }
+        ],
+        "parameters": {
+          "sampleCount": 2,
+          "aspectRatio": "16:9"
+        }
+      }
+      """, """
+      {
+        "predictions": [
+          {
+            "bytesBase64Encoded": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+            "mimeType": "image/png"
+          },
+          {
+            "bytesBase64Encoded": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAGA8fLCKwAAAABJRU5ErkJggg==",
+            "mimeType": "image/png"
+          }
+        ]
+      }
+      """);
+
+    var options = new ImageGenerationOptions
+    {
+      Count = 2,
+      ImageSize = new System.Drawing.Size(2048, 1024)
+    };
+
+    var response = await imageGenerator.GenerateImagesAsync("A blue car", options);
+
+    Assert.IsNotNull(response);
+    Assert.AreEqual(2, response.Contents.Count);
+    Assert.IsInstanceOfType(response.Contents[0], typeof(DataContent));
+    Assert.IsInstanceOfType(response.Contents[1], typeof(DataContent));
+    
+    var dataContent1 = (DataContent)response.Contents[0];
+    var dataContent2 = (DataContent)response.Contents[1];
+    Assert.IsNotNull(dataContent1.Data);
+    Assert.IsNotNull(dataContent2.Data);
+    Assert.IsTrue(dataContent1.Data.Length > 0);
+    Assert.IsTrue(dataContent2.Data.Length > 0);
+    Assert.AreEqual("image/png", dataContent1.MediaType);
+    Assert.AreEqual("image/png", dataContent2.MediaType);
+  }
+
+  private static IChatClient CreateChatClient(string expectedRequest, string actualResponse, bool makeRealRequest = false)
+  {
+    Models models = new(new MockApiClient(expectedRequest, actualResponse, makeRealRequest));
+    return models.AsIChatClient("gemini-2.5-pro");
+  }
+
+  private static IImageGenerator CreateImageGenerator(string expectedRequest, string actualResponse, bool makeRealRequest = false)
+  {
+    Models models = new(new MockApiClient(expectedRequest, actualResponse, makeRealRequest));
+    return models.AsIImageGenerator("imagen-3.0-generate-001");
+  }
+
+  private static IEmbeddingGenerator<string, Embedding<float>> CreateEmbeddingGenerator(
+    string expectedRequest,
+    string actualResponse,
+    string defaultModelId = "text-embedding-004",
+    int? defaultDimensions = null,
+    bool makeRealRequest = false)
+  {
+    Models models = new(new MockApiClient(expectedRequest, actualResponse, makeRealRequest));
+    return models.AsIEmbeddingGenerator(defaultModelId, defaultDimensions);
+  }
+
+  private sealed class MockApiClient : ApiClient
+  {
+    private readonly string _expectedRequest;
+    private readonly string _actualResponse;
+    private readonly bool _makeRealRequest;
+
+    public MockApiClient(string expectedRequest, string actualResponse, bool makeRealRequest = false) : base("fake_api_key", new() { BaseUrl = "http://localhost/" })
+    {
+      _expectedRequest = expectedRequest;
+      _actualResponse = actualResponse;
+      _makeRealRequest = makeRealRequest;
+    }
+
+    private static bool JsonEquals(string json1, string json2)
+    {
+      using var doc1 = JsonDocument.Parse(json1);
+      using var doc2 = JsonDocument.Parse(json2);
+      return JsonElementEquals(doc1.RootElement, doc2.RootElement);
+    }
+
+    private static bool JsonElementEquals(JsonElement e1, JsonElement e2)
+    {
+      if (e1.ValueKind == e2.ValueKind) switch (e1.ValueKind)
+      {
+        case JsonValueKind.Object:
+          var props1 = e1.EnumerateObject().OrderBy(p => p.Name).ToList();
+          var props2 = e2.EnumerateObject().OrderBy(p => p.Name).ToList();
+          return
+            props1.Count == props2.Count && props1.Zip(props2).All(pair =>
+              pair.First.Name == pair.Second.Name && JsonElementEquals(pair.First.Value, pair.Second.Value));
+
+        case JsonValueKind.Array:
+          var arr1 = e1.EnumerateArray().ToList();
+          var arr2 = e2.EnumerateArray().ToList();
+          return arr1.Count == arr2.Count && arr1.Zip(arr2).All(pair => JsonElementEquals(pair.First, pair.Second));
+
+        case JsonValueKind.Number:
+          return Math.Abs(e1.GetDouble() - e2.GetDouble()) < 0.0001;
+
+        case JsonValueKind.String:
+          return e1.GetString() == e2.GetString();
+
+        case JsonValueKind.True:
+        case JsonValueKind.False:
+        case JsonValueKind.Null:
+          return true;
+      }
+
+      return false;
+    }
+
+    internal override Task<ApiResponse> RequestAsync(HttpMethod httpMethod, string path, byte[] requestBytes, HttpOptions? requestHttpOptions, CancellationToken cancellationToken = default) =>
+      RequestAsync(httpMethod, path, Encoding.UTF8.GetString(requestBytes), requestHttpOptions, cancellationToken);
+
+    public override async Task<ApiResponse> RequestAsync(
+      HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, CancellationToken cancellationToken = default)
+    {
+      string responseJson = _actualResponse;
+
+      if (_makeRealRequest)
+      {
+        using var client = new HttpApiClient(System.Environment.GetEnvironmentVariable("AI:Google:ApiKey"), null);
+        using var response = await client.RequestAsync(HttpMethod.Post, @"models/gemini-2.5-pro:generateContent", @"{ ""contents"":[{""parts"":[{""text"":""Hello, world!""}],""role"":""user""}],""generationConfig"":{}}", null);
+        responseJson = await response.GetEntity().ReadAsStringAsync();
+      }
+
+      // Use JSON-aware comparison to handle property ordering, Unicode escapes, and float precision
+      Assert.IsTrue(JsonEquals(_expectedRequest, requestJson),
+        $"Expected:<{_expectedRequest}>. Actual:<{requestJson}>.");
+      return new HttpApiResponse(new HttpResponseMessage()
+      {
+        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+      });
+    }
+
+    public override async IAsyncEnumerable<ApiResponse> RequestStreamAsync(
+      HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      string responseData = _actualResponse;
+      
+      if (_makeRealRequest)
+      {
+        // Make a real streaming request
+        using var client = new HttpApiClient(System.Environment.GetEnvironmentVariable("AI:Google:ApiKey"), null);
+        StringBuilder fullResponse = new();
+        
+        await foreach (var apiResponse in client.RequestStreamAsync(httpMethod, path, requestJson, requestHttpOptions, cancellationToken))
+        {
+          var responseJson = await apiResponse.GetEntity().ReadAsStringAsync();
+          fullResponse.AppendLine("data: " + responseJson);
+          Console.WriteLine($"CAPTURED STREAMING CHUNK: {responseJson}");
+        }
+        
+        responseData = fullResponse.ToString();
+        Console.WriteLine($"\n\nFULL CAPTURED REQUEST:\n{requestJson}");
+        Console.WriteLine($"\n\nFULL CAPTURED RESPONSE:\n{responseData}");
+      }
+      else
+      {
+        // Use JSON-aware comparison to handle property ordering, Unicode escapes, and float precision
+        Assert.IsTrue(JsonEquals(_expectedRequest, requestJson),
+          $"Expected:<{_expectedRequest}>. Actual:<{requestJson}>.");
+      }
+      
+      // Split streaming response by "data:" prefix (if present)
+      foreach (var chunk in responseData.Split(["data:"], StringSplitOptions.RemoveEmptyEntries))
+      {
+        var trimmedChunk = chunk.Trim();
+        if (!string.IsNullOrEmpty(trimmedChunk))
+        {
+          await Task.Yield();
+          yield return new StreamingApiResponse(trimmedChunk, new HttpResponseMessage());
+        }
+      }
+    }
+
+    private static string RemoveWhitespace(string input) => Regex.Replace(input, @"\s+", "");
+  }
+}
+

--- a/Google.GenAI.Tests/Netstandard2_0Tests/Google.GenAI.Netstandard2_0.Tests.csproj
+++ b/Google.GenAI.Tests/Netstandard2_0Tests/Google.GenAI.Netstandard2_0.Tests.csproj
@@ -6,11 +6,12 @@
     <Nullable>enable</Nullable>
     <warningLevel>1</warningLevel>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <NoWarn>MEAI001</NoWarn>
   </PropertyGroup>
 
   <!-- Include all test source files from parent directory -->
   <ItemGroup>
-    <Compile Include="../**/*.cs" Exclude="../Netstandard2_1Tests/**/*.cs;../bin/**;../obj/**" />
+    <Compile Include="../**/*.cs" Exclude="../Netstandard2_0Tests/**/*.cs;../bin/**;../obj/**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Google.GenAI.Tests/Netstandard2_0Tests/packages.lock.json
+++ b/Google.GenAI.Tests/Netstandard2_0Tests/packages.lock.json
@@ -64,11 +64,12 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
         "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0"
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       },
       "Castle.Core": {
@@ -204,6 +205,14 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -213,6 +222,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -242,13 +256,15 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -262,14 +278,20 @@
           "System.Management": "7.0.2"
         }
       },
-      "System.Collections.Immutable": {
+      "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Text.Json": "10.0.1"
         }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
       }
     }
   }

--- a/Google.GenAI.Tests/packages.lock.json
+++ b/Google.GenAI.Tests/packages.lock.json
@@ -189,6 +189,14 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -198,6 +206,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -227,16 +240,15 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
-          "Google.Apis.Auth": "[1.69.0, )"
+          "Google.Apis.Auth": "[1.69.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.1.1, )",
+          "MimeTypes": "[2.5.2, )"
         }
       },
       "Google.Apis.Auth": {
@@ -250,23 +262,29 @@
           "System.Management": "7.0.2"
         }
       },
-      "System.Collections.Immutable": {
+      "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Text.Json": "10.0.1"
         }
+      },
+      "MimeTypes": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.2, )",
+        "resolved": "2.5.2",
+        "contentHash": "vm4xrNt+i6OVRQ8vhfCcmDIUg3qvjyCTkSTNVTDFohsG6CXEpMaVFkidECL6yRYpHDnz4TqXhDoEQAcnHCu/tw=="
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "6.0.0",
-        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/Google.GenAI.sln
+++ b/Google.GenAI.sln
@@ -43,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.GenAI.Netstandard2_0.Tests", "Google.GenAI.Tests\Netstandard2_0Tests\Google.GenAI.Netstandard2_0.Tests.csproj", "{750DC926-0B2D-504C-7168-FEE801B21D12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +91,10 @@ Global
 		{794DEEC8-86DB-2ACD-25B9-3D360F800432}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{794DEEC8-86DB-2ACD-25B9-3D360F800432}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{794DEEC8-86DB-2ACD-25B9-3D360F800432}.Release|Any CPU.Build.0 = Release|Any CPU
+		{750DC926-0B2D-504C-7168-FEE801B21D12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{750DC926-0B2D-504C-7168-FEE801B21D12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{750DC926-0B2D-504C-7168-FEE801B21D12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{750DC926-0B2D-504C-7168-FEE801B21D12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,6 +110,7 @@ Global
 		{9245217E-BC52-BC71-07B7-879540F9BFC3} = {814B1E4F-AA62-4EE1-BC14-8DF9A3088398}
 		{976E5ABB-E26C-053A-3462-591503F3E67D} = {814B1E4F-AA62-4EE1-BC14-8DF9A3088398}
 		{794DEEC8-86DB-2ACD-25B9-3D360F800432} = {814B1E4F-AA62-4EE1-BC14-8DF9A3088398}
+		{750DC926-0B2D-504C-7168-FEE801B21D12} = {FD96F647-C6D2-4C03-9BCD-5491AB949CDF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5C5D6D6-276F-43FA-89C8-AA44F98787DF}

--- a/Google.GenAI/ApiClient.cs
+++ b/Google.GenAI/ApiClient.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -186,10 +185,10 @@ namespace Google.GenAI
         mergedOptions.Timeout = optionsToApply?.Timeout;
       }
 
-      var currentHeaders = this.HttpOptions.Headers ?? new Dictionary<string, string>(ImmutableDictionary<string, string>.Empty);
-      var newHeaders = optionsToApply.Headers ?? new Dictionary<string, string>(ImmutableDictionary<string, string>.Empty);
+      var currentHeaders = this.HttpOptions.Headers ?? new Dictionary<string, string>();
+      var newHeaders = optionsToApply?.Headers ?? new Dictionary<string, string>();
 
-      var headersBuilder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+      var headersBuilder = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
       foreach (var header in currentHeaders)
       {
@@ -214,21 +213,22 @@ namespace Google.GenAI
           headersBuilder[header.Key] = header.Value;
         }
       }
-      mergedOptions.Headers = new Dictionary<string, string>(headersBuilder.ToImmutable());
+      mergedOptions.Headers = headersBuilder;
 
       return mergedOptions;
     }
 
     internal static HttpOptions GetDefaultHttpOptions(bool vertexAI, string? location)
     {
-      var defaultHeadersBuilder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
-      defaultHeadersBuilder.Add("Content-Type", "application/json");
-      defaultHeadersBuilder.Add("User-Agent", GetLibraryVersion());
-      defaultHeadersBuilder.Add("x-goog-api-client", GetLibraryVersion());
 
       var defaultHttpOptions = new HttpOptions
       {
-        Headers = new Dictionary<string, string>(defaultHeadersBuilder.ToImmutable()),
+        Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          { "Content-Type", "application/json" },
+          { "User-Agent", GetLibraryVersion() },
+          { "x-goog-api-client", GetLibraryVersion() }
+        },
       };
 
       if (vertexAI)

--- a/Google.GenAI/Google.GenAI.csproj
+++ b/Google.GenAI/Google.GenAI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../ReleaseVersion.xml" />
   <PropertyGroup>
@@ -23,20 +23,15 @@
   <PropertyGroup>
     <WarningsAsErrors>$(WarningsAsErrors);CS1570</WarningsAsErrors><NoWarn>$(NoWarn);CS1591</NoWarn>
     <WarningsNotAsErrors>IDE0005</WarningsNotAsErrors>
+    <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MimeTypes">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Google.Apis.Auth" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="MimeTypes" />
     <InternalsVisibleTo Include="Google.GenAI.Tests" />
     <InternalsVisibleTo Include="Google.GenAI.Netstandard2_0.Tests" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Google.GenAI/GoogleGenAIChatClient.cs
+++ b/Google.GenAI/GoogleGenAIChatClient.cs
@@ -1,0 +1,708 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using Google.Apis.Util;
+using Google.GenAI;
+using Google.GenAI.Types;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides an <see cref="IChatClient"/> implementation based on <see cref="Client"/>.</summary>
+internal sealed class GoogleGenAIChatClient : IChatClient
+{
+  /// <summary>A thought signature that can be used to skip thought validation when sending foreign function calls.</summary>
+  /// <remarks>
+  /// See https://ai.google.dev/gemini-api/docs/thought-signatures#faqs.
+  /// This is more common in agentic scenarios, where a chat history is built up across multiple providers/models.
+  /// </remarks>
+  private static readonly byte[] s_skipThoughtValidation = Encoding.UTF8.GetBytes("skip_thought_signature_validator");
+
+  /// <summary>The wrapped <see cref="Client"/> instance (optional).</summary>
+  private readonly Client? _client;
+
+  /// <summary>The wrapped <see cref="Models"/> instance.</summary>
+  private readonly Models _models;
+
+  /// <summary>The default model that should be used when no override is specified.</summary>
+  private readonly string? _defaultModelId;
+
+  /// <summary>Lazily-initialized metadata describing the implementation.</summary>
+  private ChatClientMetadata? _metadata;
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIChatClient"/> instance.</summary>
+  public GoogleGenAIChatClient(Client client, string? defaultModelId)
+  {
+    _client = client;
+    _models = client.Models;
+    _defaultModelId = defaultModelId;
+  }
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIChatClient"/> instance.</summary>
+  public GoogleGenAIChatClient(Models client, string? defaultModelId)
+  {
+    _models = client;
+    _defaultModelId = defaultModelId;
+  }
+
+  /// <inheritdoc />
+  public async Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(messages, nameof(messages));
+
+    // Create the request.
+    (string? modelId, List<Content> contents, GenerateContentConfig config) = CreateRequest(messages, options);
+
+    // Send it.
+    GenerateContentResponse generateResult = await _models.GenerateContentAsync(modelId!, contents, config).ConfigureAwait(false);
+
+    // Create the response.
+    ChatResponse chatResponse = new(new ChatMessage(ChatRole.Assistant, new List<AIContent>()))
+    {
+      CreatedAt = generateResult.CreateTime is { } dt ? new DateTimeOffset(dt) : null,
+      ModelId = !string.IsNullOrWhiteSpace(generateResult.ModelVersion) ? generateResult.ModelVersion : modelId,
+      RawRepresentation = generateResult,
+      ResponseId = generateResult.ResponseId,
+    };
+
+    // Populate the response messages.
+    chatResponse.FinishReason = PopulateResponseContents(generateResult, chatResponse.Messages[0].Contents);
+
+    // Populate usage information if there is any.
+    if (generateResult.UsageMetadata is { } usageMetadata)
+    {
+      chatResponse.Usage = ExtractUsageDetails(usageMetadata);
+    }
+
+    // Return the response.
+    return chatResponse;
+  }
+
+  /// <inheritdoc />
+  public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(messages, nameof(messages));
+
+    // Create the request.
+    (string? modelId, List<Content> contents, GenerateContentConfig config) = CreateRequest(messages, options);
+
+    // Send it, and process the results.
+    await foreach (GenerateContentResponse generateResult in _models.GenerateContentStreamAsync(modelId!, contents, config).WithCancellation(cancellationToken).ConfigureAwait(false))
+    {
+      // Create a response update for each result in the stream.
+      ChatResponseUpdate responseUpdate = new(ChatRole.Assistant, new List<AIContent>())
+      {
+        CreatedAt = generateResult.CreateTime is { } dt ? new DateTimeOffset(dt) : null,
+        ModelId = !string.IsNullOrWhiteSpace(generateResult.ModelVersion) ? generateResult.ModelVersion : modelId,
+        RawRepresentation = generateResult,
+        ResponseId = generateResult.ResponseId,
+      };
+
+      // Populate the response update contents.
+      responseUpdate.FinishReason = PopulateResponseContents(generateResult, responseUpdate.Contents);
+
+      // Populate usage information if there is any.
+      if (generateResult.UsageMetadata is { } usageMetadata)
+      {
+        responseUpdate.Contents.Add(new UsageContent(ExtractUsageDetails(usageMetadata)));
+      }
+
+      // Yield the update.
+      yield return responseUpdate;
+    }
+  }
+
+  /// <inheritdoc />
+  public object? GetService(System.Type serviceType, object? serviceKey = null)
+  {
+    Utilities.ThrowIfNull(serviceType, nameof(serviceType));
+
+    if (serviceKey is null)
+    {
+      // If there's a request for metadata, lazily-initialize it and return it. We don't need to worry about race conditions,
+      // as there's no requirement that the same instance be returned each time, and creation is idempotent.
+      if (serviceType == typeof(ChatClientMetadata))
+      {
+        return _metadata ??= new("gcp.gen_ai", new("https://generativelanguage.googleapis.com/"), defaultModelId: _defaultModelId);
+      }
+
+      // Allow a consumer to "break glass" and access the underlying client if they need it.
+      if (serviceType.IsInstanceOfType(_models))
+      {
+        return _models;
+      }
+
+      if (_client is not null && serviceType.IsInstanceOfType(_client))
+      {
+        return _client;
+      }
+
+      if (serviceType.IsInstanceOfType(this))
+      {
+        return this;
+      }
+    }
+
+    return null;
+  }
+
+  /// <inheritdoc />
+  void IDisposable.Dispose() { /* nop */ }
+
+  /// <summary>Creates the message parameters for <see cref="Models.GenerateContentAsync(string, List{Content}, GenerateContentConfig?)"/> from <paramref name="messages"/> and <paramref name="options"/>.</summary>
+  private (string? ModelId, List<Content> Contents, GenerateContentConfig Config) CreateRequest(IEnumerable<ChatMessage> messages, ChatOptions? options)
+  {
+    // Create the GenerateContentConfig object. If the options contains a RawRepresentationFactory, try to use it to
+    // create the request instance, allowing the caller to populate it with GenAI-specific options. Otherwise, create
+    // a new instance directly.
+    string? model = _defaultModelId;
+    List<Content> contents = new();
+    GenerateContentConfig config = options?.RawRepresentationFactory?.Invoke(this) as GenerateContentConfig ?? new();
+
+    if (options is not null)
+    {
+      if (options.FrequencyPenalty is { } frequencyPenalty)
+      {
+        config.FrequencyPenalty ??= frequencyPenalty;
+      }
+
+      if (options.Instructions is { } instructions)
+      {
+        ((config.SystemInstruction ??= new()).Parts ??= new()).Add(new() { Text = instructions });
+      }
+
+      if (options.MaxOutputTokens is { } maxOutputTokens)
+      {
+        config.MaxOutputTokens ??= maxOutputTokens;
+      }
+
+      if (!string.IsNullOrWhiteSpace(options.ModelId))
+      {
+        model = options.ModelId;
+      }
+
+      if (options.PresencePenalty is { } presencePenalty)
+      {
+        config.PresencePenalty ??= presencePenalty;
+      }
+
+      if (options.Seed is { } seed)
+      {
+        config.Seed ??= (int)seed;
+      }
+
+      if (options.StopSequences is { } stopSequences)
+      {
+        (config.StopSequences ??= new()).AddRange(stopSequences);
+      }
+
+      if (options.Temperature is { } temperature)
+      {
+        config.Temperature ??= temperature;
+      }
+
+      if (options.TopP is { } topP)
+      {
+        config.TopP ??= topP;
+      }
+
+      if (options.TopK is { } topK)
+      {
+        config.TopK ??= topK;
+      }
+
+      // Populate tools. Each kind of tool is added on its own, except for function declarations,
+      // which are grouped into a single FunctionDeclaration.
+      List<FunctionDeclaration>? functionDeclarations = null;
+      if (options.Tools is { } tools)
+      {
+        foreach (var tool in tools)
+        {
+          switch (tool)
+          {
+            case AIFunctionDeclaration af:
+              functionDeclarations ??= new();
+              functionDeclarations.Add(new()
+              {
+                Name = af.Name,
+                Description = af.Description ?? "",
+                ParametersJsonSchema = af.JsonSchema,
+              });
+              break;
+
+            case HostedCodeInterpreterTool:
+              (config.Tools ??= new()).Add(new() { CodeExecution = new() });
+              break;
+
+            case HostedFileSearchTool:
+              (config.Tools ??= new()).Add(new() { Retrieval = new() });
+              break;
+
+            case HostedWebSearchTool:
+              (config.Tools ??= new()).Add(new() { GoogleSearch = new() });
+              break;
+          }
+        }
+      }
+
+      if (functionDeclarations is { Count: > 0 })
+      {
+        Tool functionTools = new();
+        (functionTools.FunctionDeclarations ??= new()).AddRange(functionDeclarations);
+        (config.Tools ??= new()).Add(functionTools);
+      }
+
+      // Transfer over the tool mode if there are any tools.
+      if (options.ToolMode is { } toolMode && config.Tools?.Count > 0)
+      {
+        switch (toolMode)
+        {
+          case NoneChatToolMode:
+            config.ToolConfig = new() { FunctionCallingConfig = new() { Mode = FunctionCallingConfigMode.NONE } };
+            break;
+
+          case AutoChatToolMode:
+            config.ToolConfig = new() { FunctionCallingConfig = new() { Mode = FunctionCallingConfigMode.AUTO } };
+            break;
+
+          case RequiredChatToolMode required:
+            config.ToolConfig = new() { FunctionCallingConfig = new() { Mode = FunctionCallingConfigMode.ANY } };
+            if (required.RequiredFunctionName is not null)
+            {
+              ((config.ToolConfig.FunctionCallingConfig ??= new()).AllowedFunctionNames ??= new()).Add(required.RequiredFunctionName);
+            }
+            break;
+        }
+      }
+
+      // Set the response format if specified.
+      if (options.ResponseFormat is ChatResponseFormatJson responseFormat)
+      {
+        config.ResponseMimeType = "application/json";
+        if (responseFormat.Schema is { } schema)
+        {
+          config.ResponseJsonSchema = schema;
+        }
+      }
+    }
+
+    // Transfer messages to request, handling system messages specially
+    Dictionary<string, string>? callIdToFunctionNames = null;
+    foreach (var message in messages)
+    {
+      if (message.Role == ChatRole.System)
+      {
+        string instruction = message.Text;
+        if (!string.IsNullOrWhiteSpace(instruction))
+        {
+          ((config.SystemInstruction ??= new()).Parts ??= new()).Add(new() { Text = instruction });
+        }
+
+        continue;
+      }
+
+      Content content = new() { Role = message.Role == ChatRole.Assistant ? "model" : "user" };
+      content.Parts ??= new();
+      AddPartsForAIContents(ref callIdToFunctionNames, message.Contents, content.Parts);
+
+      contents.Add(content);
+    }
+
+    // Make sure the request contains at least one content part (the request would always fail if empty).
+    if (!contents.SelectMany(c => c.Parts ?? Enumerable.Empty<Part>()).Any())
+    {
+      contents.Add(new() { Role = "user", Parts = new() { { new() { Text = "" } } } });
+    }
+
+    return (model, contents, config);
+  }
+
+  /// <summary>Creates <see cref="Part"/>s for <paramref name="contents"/> and adds them to <paramref name="parts"/>.</summary>
+  private static void AddPartsForAIContents(ref Dictionary<string, string>? callIdToFunctionNames, IList<AIContent> contents, List<Part> parts)
+  {
+    for (int i = 0; i < contents.Count; i++)
+    {
+      var content = contents[i];
+
+      byte[]? thoughtSignature = null;
+      if (content is not TextReasoningContent { ProtectedData: not null } &&
+          i + 1 < contents.Count &&
+          contents[i + 1] is TextReasoningContent nextReasoning &&
+          string.IsNullOrWhiteSpace(nextReasoning.Text) &&
+          nextReasoning.ProtectedData is { } protectedData)
+      {
+        i++;
+        thoughtSignature = Convert.FromBase64String(protectedData);
+      }
+
+      // Before the main switch, do any necessary state tracking. We want to do this
+      // even if the AIContent includes a Part as its RawRepresentation.
+      if (content is FunctionCallContent fcc)
+      {
+        (callIdToFunctionNames ??= new())[fcc.CallId] = fcc.Name;
+        callIdToFunctionNames[""] = fcc.Name; // track last function name in case calls don't have IDs
+      }
+
+      Part? part = null;
+      switch (content)
+      {
+        case AIContent aic when aic.RawRepresentation is Part rawPart:
+          part = rawPart;
+          break;
+
+        case TextContent textContent:
+          part = new() { Text = textContent.Text };
+          break;
+
+        case TextReasoningContent reasoningContent:
+          part = new()
+          {
+            Thought = true,
+            Text = !string.IsNullOrWhiteSpace(reasoningContent.Text) ? reasoningContent.Text : null,
+            ThoughtSignature = reasoningContent.ProtectedData is not null ? Convert.FromBase64String(reasoningContent.ProtectedData) : null,
+          };
+          break;
+
+        case DataContent dataContent:
+          part = new()
+          {
+            InlineData = new()
+            {
+              MimeType = dataContent.MediaType,
+              Data = dataContent.Data.ToArray(),
+              DisplayName = dataContent.Name,
+            }
+          };
+          break;
+
+        case UriContent uriContent:
+          part = new()
+          {
+            FileData = new()
+            {
+              FileUri = uriContent.Uri.AbsoluteUri,
+              MimeType = uriContent.MediaType,
+            }
+          };
+          break;
+
+        case FunctionCallContent functionCallContent:
+          part = new()
+          {
+            FunctionCall = new()
+            {
+              Id = functionCallContent.CallId,
+              Name = functionCallContent.Name,
+              Args = functionCallContent.Arguments is null ? null : functionCallContent.Arguments as Dictionary<string, object> ?? new(functionCallContent.Arguments!),              
+            },
+            ThoughtSignature = thoughtSignature ?? s_skipThoughtValidation,
+          };
+          break;
+
+        case FunctionResultContent functionResultContent:
+          FunctionResponse funcResponse = new()
+          {
+            Id = functionResultContent.CallId,
+          };
+
+          if (callIdToFunctionNames?.TryGetValue(functionResultContent.CallId, out string? functionName) is true ||
+              callIdToFunctionNames?.TryGetValue("", out functionName) is true)
+          {
+            funcResponse.Name = functionName;
+          }
+
+          switch (functionResultContent.Result)
+          {
+            case null:
+              break;
+
+            case AIContent aic when ToFunctionResponsePart(aic) is { } singleContentBlob:
+              funcResponse.Parts = new() { singleContentBlob };
+              break;
+
+            case IEnumerable<AIContent> aiContents:
+              List<AIContent>? nonBlobContent = null;
+              foreach (var aiContent in aiContents)
+              {
+                if (ToFunctionResponsePart(aiContent) is { } contentBlob)
+                {
+                  (funcResponse.Parts ??= new()).Add(contentBlob);
+                }
+                else
+                {
+                  (nonBlobContent ??= new()).Add(aiContent);
+                }
+              }
+
+              if (nonBlobContent is not null)
+              {
+                funcResponse.Response = new() { ["result"] = nonBlobContent };
+              }
+              break;
+
+            case TextContent textContent:
+              funcResponse.Response = new() { ["result"] = textContent.Text };
+              break;
+
+            default:
+              funcResponse.Response = new() { ["result"] = functionResultContent.Result };
+              break;
+          }
+
+          part = new()
+          {
+            FunctionResponse = funcResponse,
+          };
+
+          static FunctionResponsePart? ToFunctionResponsePart(AIContent content)
+          {
+            switch (content)
+            {
+              case AIContent when content.RawRepresentation is FunctionResponsePart functionResponsePart:
+                return functionResponsePart;
+
+              case DataContent dc when IsSupportedMediaType(dc.MediaType):
+                FunctionResponseBlob dataBlob = new()
+                {
+                  MimeType = dc.MediaType,
+                  Data = dc.Data.Span.ToArray(),
+                };
+
+                if (!string.IsNullOrWhiteSpace(dc.Name))
+                {
+                  dataBlob.DisplayName = dc.Name;
+                }
+
+                return new() { InlineData = dataBlob };
+
+              case UriContent uc when IsSupportedMediaType(uc.MediaType):
+                return new()
+                {
+                  FileData = new()
+                  {
+                    MimeType = uc.MediaType,
+                    FileUri = uc.Uri.AbsoluteUri,
+                  }
+                };
+
+              default:
+                return null;
+            }
+
+            // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#mm-fr
+            static bool IsSupportedMediaType(string mediaType) =>
+              // images
+              mediaType.Equals("image/png", StringComparison.OrdinalIgnoreCase) ||
+              mediaType.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase) ||
+              mediaType.Equals("image/webp", StringComparison.OrdinalIgnoreCase) ||
+              // documents
+              mediaType.Equals("application/pdf", StringComparison.OrdinalIgnoreCase) ||
+              mediaType.Equals("text/plain", StringComparison.OrdinalIgnoreCase);
+          }
+          break;
+      }
+
+      if (part is not null)
+      {
+        part.ThoughtSignature ??= thoughtSignature;
+        parts.Add(part);
+      }
+
+      thoughtSignature = null;
+    }
+  }
+
+  /// <summary>Creates <see cref="AIContent"/>s for <paramref name="parts"/> and adds them to <paramref name="contents"/>.</summary>
+  private static void AddAIContentsForParts(List<Part> parts, IList<AIContent> contents)
+  {
+    foreach (var part in parts)
+    {
+      AIContent content;
+
+      if (!string.IsNullOrEmpty(part.Text))
+      {
+        content = part.Thought is true ?
+          new TextReasoningContent(part.Text) :
+          new TextContent(part.Text);
+      }
+      else if (part.InlineData is { } inlineData)
+      {
+        content = new DataContent(inlineData.Data, inlineData.MimeType ?? "application/octet-stream")
+        {
+          Name = inlineData.DisplayName,
+        };
+      }
+      else if (part.FileData is { FileUri: not null } fileData)
+      {
+        content = new UriContent(new Uri(fileData.FileUri), fileData.MimeType ?? "application/octet-stream");
+      }
+      else if (part.FunctionCall is { Name: not null } functionCall)
+      {
+        content = new FunctionCallContent(functionCall.Id ?? "", functionCall.Name, functionCall.Args!);
+      }
+      else if (part.FunctionResponse is { } functionResponse)
+      {
+        content = new FunctionResultContent(
+          functionResponse.Id ?? "",
+          functionResponse.Response?.TryGetValue("output", out var output) is true ? output :
+          functionResponse.Response?.TryGetValue("error", out var error) is true ? error :
+          null);
+      }
+      else if (part.ExecutableCode is { Code: not null } executableCode)
+      {
+        content = new CodeInterpreterToolCallContent()
+        {
+          Inputs = new List<AIContent>()
+          {
+            new DataContent(Encoding.UTF8.GetBytes(executableCode.Code), executableCode.Language switch
+            {
+              Language.PYTHON => "text/x-python",
+              _ => "text/x-source-code",
+            })
+          },
+        };
+      }
+      else if (part.CodeExecutionResult is { Output: { } codeOutput } codeExecutionResult)
+      {
+        content = new CodeInterpreterToolResultContent()
+        {
+          Outputs = new List<AIContent>()
+           {
+             codeExecutionResult.Outcome is Outcome.OUTCOME_OK ?
+              new TextContent(codeOutput) :
+              new ErrorContent(codeOutput) { ErrorCode = codeExecutionResult.Outcome.ToString() }
+           },
+        };
+      }
+      else
+      {
+        content = new AIContent();
+      }
+
+      content.RawRepresentation = part;
+      contents.Add(content);
+
+      if (part.ThoughtSignature is { } thoughtSignature)
+      {
+        contents.Add(new TextReasoningContent(null)
+        {
+          ProtectedData = Convert.ToBase64String(thoughtSignature),
+        });
+      }
+    }
+  }
+
+  private static ChatFinishReason? PopulateResponseContents(GenerateContentResponse generateResult, IList<AIContent> responseContents)
+  {
+    ChatFinishReason? finishReason = null;
+
+    // Populate the response messages. There should only be at most one candidate, but if there are more, ignore all but the first.
+    if (generateResult.Candidates is { Count: > 0 } &&
+        generateResult.Candidates[0] is { Content: { } candidateContent } candidate)
+    {
+      // Grab the finish reason if one exists.
+      finishReason = ConvertFinishReason(candidate.FinishReason);
+
+      // Add all of the response content parts as AIContents.
+      if (candidateContent.Parts is { } parts)
+      {
+        AddAIContentsForParts(parts, responseContents);
+      }
+
+      // Add any citation metadata.
+      if (candidate.CitationMetadata is { Citations: { Count: > 0 } citations } &&
+          responseContents.OfType<TextContent>().FirstOrDefault() is TextContent textContent)
+      {
+        foreach (var citation in citations)
+        {
+          textContent.Annotations = new List<AIAnnotation>()
+          {
+              new CitationAnnotation()
+              {
+                  Title = citation.Title,
+                  Url = Uri.TryCreate(citation.Uri, UriKind.Absolute, out Uri? uri) ? uri : null,
+                  AnnotatedRegions = new List<AnnotatedRegion>()
+                  {
+                      new TextSpanAnnotatedRegion()
+                      {
+                          StartIndex = citation.StartIndex,
+                          EndIndex = citation.EndIndex,
+                      }
+                  },
+              }
+          };
+        }
+      }
+    }
+
+    // Populate error information if there is any.
+    if (generateResult.PromptFeedback is { } promptFeedback)
+    {
+      responseContents.Add(new ErrorContent(promptFeedback.BlockReasonMessage));
+    }
+
+    return finishReason;
+  }
+
+  /// <summary>Creates an M.E.AI <see cref="ChatFinishReason"/> from a Google <see cref="FinishReason"/>.</summary>
+  private static ChatFinishReason? ConvertFinishReason(FinishReason? finishReason)
+  {
+    return finishReason switch
+    {
+      null => null,
+
+      FinishReason.MAX_TOKENS =>
+        ChatFinishReason.Length,
+
+      FinishReason.MALFORMED_FUNCTION_CALL or
+      FinishReason.UNEXPECTED_TOOL_CALL =>
+        ChatFinishReason.ToolCalls,
+
+      FinishReason.FINISH_REASON_UNSPECIFIED or
+      FinishReason.STOP =>
+        ChatFinishReason.Stop,
+
+      _ => ChatFinishReason.ContentFilter,
+    };
+  }
+
+  /// <summary>Creates a <see cref="UsageDetails"/> populated from the supplied <paramref name="usageMetadata"/>.</summary>
+  private static UsageDetails ExtractUsageDetails(GenerateContentResponseUsageMetadata usageMetadata)
+  {
+    UsageDetails details = new()
+    {
+      InputTokenCount = usageMetadata.PromptTokenCount,
+      CachedInputTokenCount = usageMetadata.CachedContentTokenCount,
+      OutputTokenCount = usageMetadata.CandidatesTokenCount,
+      ReasoningTokenCount = usageMetadata.ThoughtsTokenCount,
+      TotalTokenCount = usageMetadata.TotalTokenCount,
+    };
+
+    AddIfPresent(nameof(usageMetadata.ToolUsePromptTokenCount), usageMetadata.ToolUsePromptTokenCount);
+
+    return details;
+
+    void AddIfPresent(string key, int? value)
+    {
+      if (value is int i)
+      {
+        (details.AdditionalCounts ??= new())[key] = i;
+      }
+    }
+  }
+}

--- a/Google.GenAI/GoogleGenAIEmbeddingGenerator.cs
+++ b/Google.GenAI/GoogleGenAIEmbeddingGenerator.cs
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Apis.Util;
+using Google.GenAI;
+using Google.GenAI.Types;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides an <see cref="IEmbeddingGenerator"/> implementation based on <see cref="Client"/>.</summary>
+internal sealed class GoogleGenAIEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+  /// <summary>The wrapped <see cref="Client"/> instance (optional).</summary>
+  private readonly Client? _client;
+
+  /// <summary>The wrapped <see cref="Models"/> instance.</summary>
+  private readonly Models _models;
+
+  /// <summary>The default model that should be used when no override is specified.</summary>
+  private readonly string? _defaultModelId;
+
+  /// <summary>The number of dimensions produced by the generator.</summary>
+  private readonly int? _defaultModelDimensions;
+
+  /// <summary>Lazily-initialized metadata describing the implementation.</summary>
+  private EmbeddingGeneratorMetadata? _metadata;
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIEmbeddingGenerator"/> instance.</summary>
+  public GoogleGenAIEmbeddingGenerator(
+    Client client, string? defaultModelId, int? defaultModelDimensions)
+  {
+    _client = client;
+    _models = client.Models;
+    _defaultModelId = defaultModelId;
+    _defaultModelDimensions = defaultModelDimensions;
+  }
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIEmbeddingGenerator"/> instance.</summary>
+  public GoogleGenAIEmbeddingGenerator(Models client, string? defaultModelId, int? defaultModelDimensions)
+  {
+    _models = client;
+    _defaultModelId = defaultModelId;
+    _defaultModelDimensions = defaultModelDimensions;
+  }
+
+  /// <inheritdoc />
+  public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(values, nameof(values));
+
+    string modelId = options?.ModelId ?? _defaultModelId ?? "";
+    GeneratedEmbeddings<Embedding<float>> result = new();
+
+    // Create the EmbedContentConfig object. If the options contains a RawRepresentationFactory, try to use it to
+    // create the config instance, allowing the caller to populate it with Vertex-specific options. Otherwise, create
+    // a new instance directly.
+    EmbedContentConfig config = options?.RawRepresentationFactory?.Invoke(this) as EmbedContentConfig ?? new();
+    config.OutputDimensionality ??= options?.Dimensions ?? _defaultModelDimensions;
+
+    // Make the request.
+    EmbedContentResponse response = await _models.EmbedContentAsync(
+      modelId,
+      values.Select(value => new Content() { Parts = new List<Part>() { new() { Text = value } } }).ToList(),
+      config).ConfigureAwait(false);
+
+    if (response.Embeddings is not null)
+    {
+      foreach (var embedding in response.Embeddings)
+      {
+        if (embedding.Statistics is { TokenCount: { } inputTokens } stats)
+        {
+          result.Usage ??= new();
+          result.Usage.InputTokenCount = (result.Usage.InputTokenCount ?? 0) + (long)inputTokens;
+        }
+
+        if (embedding.Values is { } embeddingValues)
+        {
+          result.Add(new Embedding<float>(embeddingValues.Select(d => (float)d).ToArray())
+          {
+            CreatedAt = DateTimeOffset.UtcNow,
+            ModelId = modelId,
+          });
+        }
+      }
+    }
+
+    if (result.Usage is not null)
+    {
+      result.Usage.TotalTokenCount = result.Usage.InputTokenCount;
+    }
+
+    return result;
+  }
+
+  /// <inheritdoc />
+  public object? GetService(System.Type serviceType, object? serviceKey = null)
+  {
+    Utilities.ThrowIfNull(serviceType, nameof(serviceType));
+
+    if (serviceKey is null)
+    {
+      // If there's a request for metadata, lazily-initialize it and return it. We don't need to worry about race conditions,
+      // as there's no requirement that the same instance be returned each time, and creation is idempotent.
+      if (serviceType == typeof(EmbeddingGeneratorMetadata))
+      {
+        return _metadata ??= new(
+          "gcp.gen_ai",
+          new("https://generativelanguage.googleapis.com/"),
+          _defaultModelId,
+          _defaultModelDimensions);
+      }
+
+      // Allow a consumer to "break glass" and access the underlying client if they need it.
+      if (serviceType.IsInstanceOfType(_models))
+      {
+        return _models;
+      }
+
+      if (_client is not null && serviceType.IsInstanceOfType(_client))
+      {
+        return _client;
+      }
+
+      if (serviceType.IsInstanceOfType(this))
+      {
+        return this;
+      }
+    }
+
+    return null;
+  }
+
+  /// <inheritdoc />
+  void IDisposable.Dispose() { /* nop */ }
+}

--- a/Google.GenAI/GoogleGenAIExtensions.cs
+++ b/Google.GenAI/GoogleGenAIExtensions.cs
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Apis.Util;
+using Google.GenAI;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides implementations of Microsoft.Extensions.AI abstractions based on <see cref="Client"/>.</summary>
+public static class GoogleGenAIExtensions
+{
+  /// <summary>
+  /// Creates an <see cref="IChatClient"/> wrapper around the specified <see cref="Client"/>.
+  /// </summary>
+  /// <param name="client">The <see cref="Client"/> to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for chat requests if not specified in <see cref="ChatOptions.ModelId"/>.</param>
+  /// <returns>An <see cref="IChatClient"/> that wraps the specified client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+  public static IChatClient AsIChatClient(this Client client, string? defaultModelId = null)
+  {
+    Utilities.ThrowIfNull(client, nameof(client));
+    return new GoogleGenAIChatClient(client, defaultModelId);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IChatClient"/> wrapper around the specified <see cref="Models"/>.
+  /// </summary>
+  /// <param name="models">The <see cref="Models"/> client to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for chat requests if not specified in <see cref="ChatOptions.ModelId"/>.</param>
+  /// <returns>An <see cref="IChatClient"/> that wraps the specified <see cref="Models"/> client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="models"/> is <see langword="null"/>.</exception>
+  public static IChatClient AsIChatClient(this Models models, string? defaultModelId = null)
+  {
+    Utilities.ThrowIfNull(models, nameof(models));
+    return new GoogleGenAIChatClient(models, defaultModelId);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IImageGenerator"/> wrapper around the specified <see cref="Client"/>.
+  /// </summary>
+  /// <param name="client">The <see cref="Client"/> to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for image generation requests if not specified in <see cref="ImageGenerationOptions.ModelId"/>.</param>
+  /// <returns>An <see cref="IImageGenerator"/> that wraps the specified client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+  public static IImageGenerator AsIImageGenerator(this Client client, string? defaultModelId = null)
+  {
+    Utilities.ThrowIfNull(client, nameof(client));
+    return new GoogleGenAIImageGenerator(client, defaultModelId);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IImageGenerator"/> wrapper around the specified <see cref="Models"/>.
+  /// </summary>
+  /// <param name="models">The <see cref="Models"/> client to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for image generation requests if not specified in <see cref="ImageGenerationOptions.ModelId"/>.</param>
+  /// <returns>An <see cref="IImageGenerator"/> that wraps the specified <see cref="Models"/> client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="models"/> is <see langword="null"/>.</exception>
+  public static IImageGenerator AsIImageGenerator(this Models models, string? defaultModelId = null)
+  {
+    Utilities.ThrowIfNull(models, nameof(models));
+    return new GoogleGenAIImageGenerator(models, defaultModelId);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IEmbeddingGenerator"/> wrapper around the specified <see cref="Client"/>.
+  /// </summary>
+  /// <param name="client">The <see cref="Client"/> to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for image generation requests if not specified in <see cref="ImageGenerationOptions.ModelId"/>.</param>
+  /// <param name="defaultModelDimensions">The number of dimensions to generate in each embedding.</param>
+  /// <returns>An <see cref="IEmbeddingGenerator"/> that wraps the specified client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+  public static IEmbeddingGenerator<string, Embedding<float>> AsIEmbeddingGenerator(
+    this Client client, string? defaultModelId = null, int? defaultModelDimensions = null)
+  {
+    Utilities.ThrowIfNull(client, nameof(client));
+    return new GoogleGenAIEmbeddingGenerator(client, defaultModelId, defaultModelDimensions);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IEmbeddingGenerator"/> wrapper around the specified <see cref="Models"/>.
+  /// </summary>
+  /// <param name="models">The <see cref="Models"/> client to wrap.</param>
+  /// <param name="defaultModelId">The default model ID to use for image generation requests if not specified in <see cref="ImageGenerationOptions.ModelId"/>.</param>
+  /// <param name="defaultModelDimensions">The number of dimensions to generate in each embedding.</param>
+  /// <returns>An <see cref="IEmbeddingGenerator"/> that wraps the specified <see cref="Models"/> client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="models"/> is <see langword="null"/>.</exception>
+  public static IEmbeddingGenerator<string, Embedding<float>> AsIEmbeddingGenerator(
+    this Models models, string? defaultModelId = null, int? defaultModelDimensions = null)
+  {
+    Utilities.ThrowIfNull(models, nameof(models));
+    return new GoogleGenAIEmbeddingGenerator(models, defaultModelId, defaultModelDimensions);
+  }
+}

--- a/Google.GenAI/GoogleGenAIImageGenerator.cs
+++ b/Google.GenAI/GoogleGenAIImageGenerator.cs
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Drawing;
+
+using Google.Apis.Util;
+using Google.GenAI;
+using Google.GenAI.Types;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides an <see cref="IImageGenerator"/> implementation based on <see cref="Client"/>.</summary>
+internal sealed class GoogleGenAIImageGenerator : IImageGenerator
+{
+  /// <summary>The wrapped <see cref="Client"/> instance (optional).</summary>
+  private readonly Client? _client;
+
+  /// <summary>The wrapped <see cref="Models"/> instance.</summary>
+  private readonly Models _models;
+
+  /// <summary>The default model that should be used when no override is specified.</summary>
+  private readonly string? _defaultModelId;
+
+  /// <summary>Lazily-initialized metadata describing the implementation.</summary>
+  private ImageGeneratorMetadata? _metadata;
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIImageGenerator"/> instance.</summary>
+  public GoogleGenAIImageGenerator(Client client, string? defaultModelId)
+  {
+    _client = client;
+    _models = client.Models;
+    _defaultModelId = defaultModelId;
+  }
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIImageGenerator"/> instance.</summary>
+  public GoogleGenAIImageGenerator(Models client, string? defaultModelId)
+  {
+    _models = client;
+    _defaultModelId = defaultModelId;
+  }
+
+  /// <inheritdoc />
+  public async Task<ImageGenerationResponse> GenerateAsync(ImageGenerationRequest request, ImageGenerationOptions? options = null, CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(request, nameof(request));
+
+    string modelId = options?.ModelId ?? _defaultModelId ?? "";
+    string prompt = request.Prompt ?? "";
+
+    GenerateImagesConfig config = options?.RawRepresentationFactory?.Invoke(this) as GenerateImagesConfig ?? new();
+    config.NumberOfImages ??= options?.Count ?? 1;
+    config.OutputMimeType ??= options?.MediaType;
+    config.AspectRatio ??= options?.ImageSize is { } imageSize && imageSize.Width > 0 && imageSize.Height > 0 ? GetClosestRatio(imageSize) : null;
+
+    var gir = await _models.GenerateImagesAsync(modelId, prompt, config).ConfigureAwait(false);
+
+    ImageGenerationResponse response = new()
+    {
+      RawRepresentation = gir
+    };
+
+    if (gir.GeneratedImages is { } generatedImages)
+    {
+      foreach (var generatedImage in generatedImages)
+      {
+        if (generatedImage.Image is { } image)
+        {
+          if (!string.IsNullOrEmpty(image.GcsUri))
+          {
+            response.Contents.Add(new UriContent(image.GcsUri, image.MimeType ?? "image/*"));
+          }
+          else if (image.ImageBytes is { } bytes)
+          {
+            response.Contents.Add(new DataContent(bytes, image.MimeType ?? "image/*"));
+          }
+        }
+      }
+    }
+
+    return response;
+  }
+
+  /// <inheritdoc />
+  public object? GetService(System.Type serviceType, object? serviceKey = null)
+  {
+    Utilities.ThrowIfNull(serviceType, nameof(serviceType));
+
+    if (serviceKey is null)
+    {
+      // If there's a request for metadata, lazily-initialize it and return it. We don't need to worry about race conditions,
+      // as there's no requirement that the same instance be returned each time, and creation is idempotent.
+      if (serviceType == typeof(ImageGeneratorMetadata))
+      {
+        return _metadata ??= new("gcp.gen_ai", new("https://generativelanguage.googleapis.com/"), defaultModelId: _defaultModelId);
+      }
+
+      // Allow a consumer to "break glass" and access the underlying client if they need it.
+      if (serviceType.IsInstanceOfType(_models))
+      {
+        return _models;
+      }
+
+      if (_client is not null && serviceType.IsInstanceOfType(_client))
+      {
+        return _client;
+      }
+
+      if (serviceType.IsInstanceOfType(this))
+      {
+        return this;
+      }
+    }
+
+    return null;
+  }
+
+  /// <inheritdoc />
+  void IDisposable.Dispose() { /* nop */ }
+
+  private static string GetClosestRatio(Size size)
+  {
+    float ratio = (float)size.Width / size.Height;
+
+    float closestDifference = float.MaxValue;
+    string result = s_knownRatios[0].Name;
+
+    foreach ((string knownRatioName, float knownRatioValue) in s_knownRatios)
+    {
+      float difference = Math.Abs(knownRatioValue - ratio);
+      if (difference < closestDifference)
+      {
+        closestDifference = difference;
+        result = knownRatioName;
+      }
+    }
+
+    return result;
+  }
+
+  private static readonly (string Name, float Ratio)[] s_knownRatios = new[]
+  {
+    ("1:1", 1f),
+    ("3:4", 3f / 4f),
+    ("4:3", 4f / 3f),
+    ("16:9", 16f / 9f),
+    ("9:16", 9f / 16f),
+  };
+}

--- a/Google.GenAI/packages.lock.json
+++ b/Google.GenAI/packages.lock.json
@@ -13,6 +13,15 @@
           "System.Management": "7.0.2"
         }
       },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
+        }
+      },
       "MimeTypes": {
         "type": "Direct",
         "requested": "[2.5.2, )",
@@ -26,30 +35,6 @@
         "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
-        }
-      },
-      "System.Collections.Immutable": {
-        "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
-        "dependencies": {
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Google.Apis": {
@@ -80,13 +65,23 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+        "resolved": "4.6.1",
+        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
       },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw==",
+        "dependencies": {
+          "System.Buffers": "4.6.1",
+          "System.Memory": "4.6.3",
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
       },
       "System.Management": {
         "type": "Transitive",
@@ -98,49 +93,64 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
         "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+          "System.Buffers": "4.6.1",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "System.Numerics.Vectors": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "resolved": "4.6.1",
+        "contentHash": "sQxefTnhagrhoq2ReR0D/6K0zJcr9Hrd6kikeXsA1I8kOCboTavcUC4r7TSfpKFeE163uMuxZcyfO1mGO3EN8Q=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "6.1.2",
+        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ==",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ==",
         "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Buffers": "4.6.1",
+          "System.Memory": "4.6.3",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "CentralTransitive",
         "requested": "[10.0.1, )",
-        "resolved": "8.0.0",
-        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+        "resolved": "10.0.1",
+        "contentHash": "E1HSLkPHXEO30JEij2pWbOuzz1Z5ND4a5l7IP1T2RgQuE0a0NzEIvtO64RNy3Otn6PFezbT80cfm3M/Cgt70PA==",
         "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.1",
+          "System.Buffers": "4.6.1",
+          "System.IO.Pipelines": "10.0.1",
+          "System.Memory": "4.6.3",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
+          "System.Text.Encodings.Web": "10.0.1",
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       }
     },
@@ -154,6 +164,15 @@
           "Google.Apis": "1.69.0",
           "Google.Apis.Core": "1.69.0",
           "System.Management": "7.0.2"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.1.1, )",
+        "resolved": "10.1.1",
+        "contentHash": "cgj8iHv4JwUpcPANZ0oLILz146Y1Oa+l280b1c1a3DjwZflH9nmYcrX952YUuqftz2sheAC2TPCGcEa6unKQgQ==",
+        "dependencies": {
+          "System.Text.Json": "10.0.1"
         }
       },
       "MimeTypes": {
@@ -188,12 +207,32 @@
         "resolved": "7.0.0",
         "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "26LbFXHKd7PmRnWlkjnYgmjd5B6HYVG+1MpTO25BdxTJnx6D0O16JPAC/S4YBqjtt4YpfGj1QO/Ss6SPMGEGQw=="
+      },
       "System.Management": {
         "type": "Transitive",
         "resolved": "7.0.2",
         "contentHash": "/qEUN91mP/MUQmJnM5y5BdT7ZoPuVrtxnFlbJ8a3kBJGhe2wCzBfnPFtK2wTtEEcf3DMGR9J00GZZfg6HRI6yA==",
         "dependencies": {
           "System.CodeDom": "7.0.0"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "cVAka0o1rJJ5/De0pjNs7jcaZk5hUGf1HGzUyVmE2MEB1Vf0h/8qsWxImk1zjitCbeD2Avaq2P2+usdvqgbeVQ=="
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "EsgwDgU1PFqhrFA9l5n+RBu76wFhNGCEwu8ITrBNhjPP3MxLyklroU5GIF8o6JYpYg6T4KD/VICfMdgPAvNp5g==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.1",
+          "System.Text.Encodings.Web": "10.0.1"
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -259,6 +259,38 @@ class GenerateContentStreamSimpleText {
 
 ```
 
+### IChatClient
+
+Microsoft.Extensions.AI provides abstractions and exchange types for working with AI services. The Google.GenAI library includes an implementation of the IChatClient interface to enable
+easy integration with applications that use these abstractions.
+```csharp
+using Google.GenAI;
+using Microsoft.Extensions.AI;
+using System.ComponentModel
+
+// assuming credentials are set up in environment variables as instructed above.
+IChatClient chatClient = new Client().AsIChatClient("gemini-2.0-flash")
+    .AsBuilder()
+    .UseFunctionInvocation()
+    .UseOpenTelemetry()
+    .Build();
+
+ChatOptions options = new()
+{
+    Tools = [AIFunctionFactory.Create(([Description("The name of the person whose age is to be retrieved")] string personName) => personName switch
+    {
+        "Alice" => 30,
+        "Bob" => 25,
+        _ => 35
+    }, "get_person_age", "Gets the age of the specified person");
+};
+
+await foreach (var update in chatClient.GetStreamingResponseAsync("How much older is Alice than Bob?", options))
+{
+    Console.Write(update);
+}
+```
+
 ### Generate Images
 
 ```csharp


### PR DESCRIPTION
Allows Client/Models to be used by anything that works with .NET's IChatClient and IImageGenerator interfaces.

e.g. using automatic function calling and otel standard convention output with Aspire dashboard:
<img width="1235" height="749" alt="image" src="https://github.com/user-attachments/assets/dde78317-9647-4247-80ac-7fa905a87fbe" />
