### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ output might be lower in quality.
 
 ```csharp
 using System.Threading.Tasks;
-using Goolge.GenAI;
+using Google.GenAI;
 using Google.GenAI.Types;
 
 public class GenerateContentWithJsonSchema {


### PR DESCRIPTION
Doesn't really matter too much but was bothering me, changed "Goolge" -> "Google" in code example in the readme