### PR TITLE
fix: Use response ID as message ID in chat client implementation

### DIFF
--- a/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
+++ b/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
@@ -518,6 +518,7 @@ public class GoogleGenAIExtensionsTest
     Assert.AreEqual("gemini-2.5-pro", response.ModelId);
     Assert.IsNotNull(response.RawRepresentation);
     Assert.AreEqual("UTQBaY2BNLXg_uMP9Y_W8Q8", ((GenerateContentResponse)response.RawRepresentation).ResponseId);
+    Assert.AreEqual("UTQBaY2BNLXg_uMP9Y_W8Q8", response.Messages[0].MessageId);
   }
 
   [TestMethod]
@@ -3628,7 +3629,8 @@ public class GoogleGenAIExtensionsTest
             },
             "index": 0
           }
-        ]
+        ],
+        "responseId": "stream123"
       }
       data: {
         "candidates": [
@@ -3643,7 +3645,8 @@ public class GoogleGenAIExtensionsTest
             },
             "index": 0
           }
-        ]
+        ],
+        "responseId": "stream123"
       }
       data: {
         "candidates": [
@@ -3664,7 +3667,8 @@ public class GoogleGenAIExtensionsTest
           "promptTokenCount": 4,
           "candidatesTokenCount": 3,
           "totalTokenCount": 7
-        }
+        },
+        "responseId": "stream123"
       }
       """);
 
@@ -3674,6 +3678,7 @@ public class GoogleGenAIExtensionsTest
       updates.Add(update);
       Assert.IsNotNull(update);
       Assert.AreEqual(ChatRole.Assistant, update.Role);
+      Assert.AreEqual("stream123", update.MessageId);
     }
 
     Assert.AreEqual(3, updates.Count);

--- a/Google.GenAI/GoogleGenAIChatClient.cs
+++ b/Google.GenAI/GoogleGenAIChatClient.cs
@@ -72,7 +72,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
     GenerateContentResponse generateResult = await _models.GenerateContentAsync(modelId!, contents, config).ConfigureAwait(false);
 
     // Create the response.
-    ChatResponse chatResponse = new(new ChatMessage(ChatRole.Assistant, new List<AIContent>()))
+    ChatResponse chatResponse = new(new ChatMessage(ChatRole.Assistant, new List<AIContent>()) { MessageId = generateResult.ResponseId })
     {
       CreatedAt = generateResult.CreateTime is { } dt ? new DateTimeOffset(dt) : null,
       ModelId = !string.IsNullOrWhiteSpace(generateResult.ModelVersion) ? generateResult.ModelVersion : modelId,
@@ -108,6 +108,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
       ChatResponseUpdate responseUpdate = new(ChatRole.Assistant, new List<AIContent>())
       {
         CreatedAt = generateResult.CreateTime is { } dt ? new DateTimeOffset(dt) : null,
+        MessageId = generateResult.ResponseId,
         ModelId = !string.IsNullOrWhiteSpace(generateResult.ModelVersion) ? generateResult.ModelVersion : modelId,
         RawRepresentation = generateResult,
         ResponseId = generateResult.ResponseId,


### PR DESCRIPTION
Gemini doesn't expose a separate message ID from response ID, but for consumers that care about message ID, we can just expose the response ID from both.