### PR TITLE
feat: Update to Microsoft.Extensions.AI.Abstractions 10.4.0

### DIFF
--- a/DemoApp/Files/packages.lock.json
+++ b/DemoApp/Files/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/GenerateContentSimpleText/packages.lock.json
+++ b/DemoApp/GenerateContentSimpleText/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/GenerateContentStreamSimpleText/packages.lock.json
+++ b/DemoApp/GenerateContentStreamSimpleText/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/JsonParser/packages.lock.json
+++ b/DemoApp/JsonParser/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/LiveAudioToAudioRealtimeInput/packages.lock.json
+++ b/DemoApp/LiveAudioToAudioRealtimeInput/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/LiveTextToTextClientContent/packages.lock.json
+++ b/DemoApp/LiveTextToTextClientContent/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/DemoApp/LiveToolCall/packages.lock.json
+++ b/DemoApp/LiveToolCall/packages.lock.json
@@ -30,8 +30,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -43,14 +43,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -67,11 +67,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -82,12 +82,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,9 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.4" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="TestServerSdk" Version="0.1.5" />

--- a/Google.GenAI.E2E.Tests/packages.lock.json
+++ b/Google.GenAI.E2E.Tests/packages.lock.json
@@ -58,12 +58,12 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       },
       "TestServerSdk": {
@@ -234,8 +234,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -265,8 +265,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "YamlDotNet": {
         "type": "Transitive",
@@ -277,7 +277,7 @@
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -294,11 +294,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {

--- a/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
+++ b/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -215,6 +216,267 @@ public class GoogleGenAIExtensionsTest
     var embeddingGenerator = models.AsIEmbeddingGenerator("text-embedding-004");
     
     Assert.ThrowsException<ArgumentNullException>(() => embeddingGenerator.GetService(null!));
+  }
+
+  [TestMethod]
+  public void AsIHostedFileClient_WithFiles_ReturnsHostedFileClient()
+  {
+    var files = new Files(new MockApiClient("", ""));
+
+    Assert.IsNotNull(files.AsIHostedFileClient());
+  }
+
+  [TestMethod]
+  public void AsIHostedFileClient_NullFiles_ThrowsArgumentNullException()
+  {
+    Files? files = null;
+    Assert.ThrowsException<ArgumentNullException>(() => files!.AsIHostedFileClient());
+  }
+
+  [TestMethod]
+  public void AsIHostedFileClient_NullClient_ThrowsArgumentNullException()
+  {
+    Client? client = null;
+    Assert.ThrowsException<ArgumentNullException>(() => client!.AsIHostedFileClient());
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_Metadata_ReturnsValidMetadata()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    var metadata = hostedFileClient.GetService<HostedFileClientMetadata>();
+
+    Assert.IsNotNull(metadata);
+    Assert.AreEqual("gcp.gen_ai", metadata.ProviderName);
+    Assert.AreEqual(new Uri("https://generativelanguage.googleapis.com/"), metadata.ProviderUri);
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_Files_ReturnsUnderlyingFiles()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    Assert.AreSame(files, hostedFileClient.GetService<Files>());
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_Client_ReturnsUnderlyingClient()
+  {
+    var client = new Client(apiKey: "fake-api-key");
+    var hostedFileClient = client.AsIHostedFileClient();
+
+    Assert.AreSame(client, hostedFileClient.GetService<Client>());
+    Assert.AreSame(client.Files, hostedFileClient.GetService<Files>());
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_Self_ReturnsSelf()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    Assert.AreSame(hostedFileClient, hostedFileClient.GetService<IHostedFileClient>());
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_NullServiceType_ThrowsArgumentNullException()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    Assert.ThrowsException<ArgumentNullException>(() => hostedFileClient.GetService(null!));
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_UnknownType_ReturnsNull()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    Assert.IsNull(hostedFileClient.GetService<string>());
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_GetService_WithKey_ReturnsNull()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    Assert.IsNull(hostedFileClient.GetService(typeof(IHostedFileClient), "somekey"));
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_GetFileInfoAsync_MapsProperties()
+  {
+    var hostedFileClient = CreateHostedFileClient(
+      """
+      {
+        "name": "files/abc123",
+        "mimeType": "application/pdf",
+        "displayName": "test.pdf",
+        "sizeBytes": "12345",
+        "createTime": "2025-01-15T10:30:00Z",
+        "state": "ACTIVE",
+        "uri": "https://generativelanguage.googleapis.com/v1beta/files/abc123"
+      }
+      """);
+
+    var result = await hostedFileClient.GetFileInfoAsync("files/abc123");
+
+    Assert.IsNotNull(result);
+    Assert.AreEqual("files/abc123", result.FileId);
+    Assert.AreEqual("application/pdf", result.MediaType);
+    Assert.AreEqual("test.pdf", result.Name);
+    Assert.AreEqual(12345L, result.SizeInBytes);
+    Assert.IsNotNull(result.CreatedAt);
+    Assert.AreEqual(new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero), result.CreatedAt);
+    Assert.IsNotNull(result.RawRepresentation);
+    Assert.IsInstanceOfType(result.RawRepresentation, typeof(Google.GenAI.Types.File));
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_GetFileInfoAsync_NullFileId_Throws()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => hostedFileClient.GetFileInfoAsync(null!));
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_DeleteAsync_ReturnsTrue()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    var result = await hostedFileClient.DeleteAsync("files/abc123");
+
+    Assert.IsTrue(result);
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_DeleteAsync_NullFileId_Throws()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => hostedFileClient.DeleteAsync(null!));
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_ListFilesAsync_EnumeratesFiles()
+  {
+    var hostedFileClient = CreateHostedFileClient(
+      """
+      {
+        "files": [
+          {
+            "name": "files/file1",
+            "mimeType": "text/plain",
+            "displayName": "notes.txt",
+            "sizeBytes": "100",
+            "createTime": "2025-01-10T08:00:00Z"
+          },
+          {
+            "name": "files/file2",
+            "mimeType": "image/png",
+            "displayName": "photo.png",
+            "sizeBytes": "5000",
+            "createTime": "2025-01-11T09:00:00Z"
+          }
+        ]
+      }
+      """);
+
+    var results = new List<HostedFileContent>();
+    await foreach (var file in hostedFileClient.ListFilesAsync())
+    {
+      results.Add(file);
+    }
+
+    Assert.AreEqual(2, results.Count);
+
+    Assert.AreEqual("files/file1", results[0].FileId);
+    Assert.AreEqual("text/plain", results[0].MediaType);
+    Assert.AreEqual("notes.txt", results[0].Name);
+    Assert.AreEqual(100L, results[0].SizeInBytes);
+
+    Assert.AreEqual("files/file2", results[1].FileId);
+    Assert.AreEqual("image/png", results[1].MediaType);
+    Assert.AreEqual("photo.png", results[1].Name);
+    Assert.AreEqual(5000L, results[1].SizeInBytes);
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_ListFilesAsync_EmptyList_ReturnsNoFiles()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    var results = new List<HostedFileContent>();
+    await foreach (var file in hostedFileClient.ListFilesAsync())
+    {
+      results.Add(file);
+    }
+
+    Assert.AreEqual(0, results.Count);
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_DownloadAsync_ReturnsStreamWithMetadata()
+  {
+    var hostedFileClient = CreateHostedFileClient(
+      // First call: GetAsync for file metadata
+      """
+      {
+        "name": "files/abc123",
+        "mimeType": "text/plain",
+        "displayName": "hello.txt",
+        "sizeBytes": "13"
+      }
+      """,
+      // Second call: DownloadStreamAsync returns the actual file content
+      "Hello, world!");
+
+    using var stream = await hostedFileClient.DownloadAsync("files/abc123");
+
+    Assert.IsNotNull(stream);
+    Assert.AreEqual("text/plain", stream.MediaType);
+    Assert.AreEqual("hello.txt", stream.FileName);
+
+    using var reader = new StreamReader(stream);
+    var content = await reader.ReadToEndAsync();
+    Assert.AreEqual("Hello, world!", content);
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_DownloadAsync_NullFileId_Throws()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => hostedFileClient.DownloadAsync(null!));
+  }
+
+  [TestMethod]
+  public async Task IHostedFileClient_UploadAsync_NullContent_Throws()
+  {
+    var hostedFileClient = CreateHostedFileClient("{}");
+
+    await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => hostedFileClient.UploadAsync(null!));
+  }
+
+  [TestMethod]
+  public void IHostedFileClient_Dispose_DoesNotThrow()
+  {
+    var files = new Files(new MockApiClient("", ""));
+    var hostedFileClient = files.AsIHostedFileClient();
+
+    ((IDisposable)hostedFileClient).Dispose();
+  }
+
+  private static IHostedFileClient CreateHostedFileClient(params string[] responses)
+  {
+    var files = new Files(new QueueMockApiClient(responses));
+    return files.AsIHostedFileClient();
   }
 
   [TestMethod]
@@ -5032,6 +5294,109 @@ public class GoogleGenAIExtensionsTest
   }
 
   [TestMethod]
+  public async Task IChatClient_ResponseWithWebSearchGrounding()
+  {
+    IChatClient client = CreateChatClient("""
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "What is the weather in NYC?"
+              }
+            ],
+            "role": "user"
+          }
+        ],
+        "generationConfig": {}
+      }
+      """, """
+      {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "The current weather in NYC is 72°F and sunny."
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "groundingMetadata": {
+              "webSearchQueries": [
+                "weather in NYC",
+                "current NYC weather"
+              ],
+              "groundingChunks": [
+                {
+                  "web": {
+                    "uri": "https://weather.com/nyc",
+                    "title": "NYC Weather - Weather.com"
+                  }
+                },
+                {
+                  "web": {
+                    "uri": "https://www.accuweather.com/nyc",
+                    "title": "NYC Weather | AccuWeather"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 10,
+          "candidatesTokenCount": 20,
+          "totalTokenCount": 30
+        },
+        "modelVersion": "gemini-2.0-flash"
+      }
+      """);
+
+    var response = await client.GetResponseAsync("What is the weather in NYC?");
+
+    Assert.IsNotNull(response);
+    Assert.AreEqual(1, response.Messages.Count);
+
+    var contents = response.Messages[0].Contents;
+
+    // Should have: TextContent, WebSearchToolCallContent, WebSearchToolResultContent
+    Assert.AreEqual(3, contents.Count);
+
+    Assert.IsInstanceOfType(contents[0], typeof(TextContent));
+    Assert.IsTrue(((TextContent)contents[0]).Text.Contains("72°F"));
+
+    // Web search tool call content
+    Assert.IsInstanceOfType(contents[1], typeof(WebSearchToolCallContent));
+    var searchCall = (WebSearchToolCallContent)contents[1];
+    Assert.IsNotNull(searchCall.Queries);
+    Assert.AreEqual(2, searchCall.Queries.Count);
+    Assert.AreEqual("weather in NYC", searchCall.Queries[0]);
+    Assert.AreEqual("current NYC weather", searchCall.Queries[1]);
+
+    // Web search tool result content
+    Assert.IsInstanceOfType(contents[2], typeof(WebSearchToolResultContent));
+    var searchResult = (WebSearchToolResultContent)contents[2];
+    Assert.IsNotNull(searchResult.Results);
+    Assert.AreEqual(2, searchResult.Results.Count);
+
+    // Both results should be UriContent with title in AdditionalProperties
+    Assert.IsInstanceOfType(searchResult.Results[0], typeof(UriContent));
+    var firstResult = (UriContent)searchResult.Results[0];
+    Assert.AreEqual("https://weather.com/nyc", firstResult.Uri.ToString());
+    Assert.AreEqual("NYC Weather - Weather.com", firstResult.AdditionalProperties?["title"]);
+
+    Assert.IsInstanceOfType(searchResult.Results[1], typeof(UriContent));
+    var secondResult = (UriContent)searchResult.Results[1];
+    Assert.AreEqual("https://www.accuweather.com/nyc", secondResult.Uri.ToString());
+    Assert.AreEqual("NYC Weather | AccuWeather", secondResult.AdditionalProperties?["title"]);
+
+    // CallId should match between call and result
+    Assert.AreEqual(searchCall.CallId, searchResult.CallId);
+  }
+
+  [TestMethod]
   public async Task IImageGeneration_BasicRequest()
   {
     IImageGenerator imageGenerator = CreateImageGenerator("""
@@ -5261,6 +5626,38 @@ public class GoogleGenAIExtensionsTest
     }
 
     private static string RemoveWhitespace(string input) => Regex.Replace(input, @"\s+", "");
+  }
+
+  /// <summary>A mock <see cref="ApiClient"/> that returns queued responses in order without asserting on request content.</summary>
+  private sealed class QueueMockApiClient : ApiClient
+  {
+    private readonly Queue<string> _responses;
+
+    public QueueMockApiClient(params string[] responses) : base(apiKey: "fake_api_key", customHttpOptions: new() { BaseUrl = "http://localhost/" })
+    {
+      _responses = new Queue<string>(responses);
+    }
+
+    internal override Task<ApiResponse> RequestAsync(HttpMethod httpMethod, string path, byte[] requestBytes, HttpOptions? requestHttpOptions, CancellationToken cancellationToken = default) =>
+      RequestAsync(httpMethod, path, Encoding.UTF8.GetString(requestBytes), requestHttpOptions, cancellationToken);
+
+    public override Task<ApiResponse> RequestAsync(
+      HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, CancellationToken cancellationToken = default)
+    {
+      string responseJson = _responses.Count > 0 ? _responses.Dequeue() : "{}";
+      return Task.FromResult<ApiResponse>(new HttpApiResponse(new HttpResponseMessage()
+      {
+        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+      }));
+    }
+
+    public override async IAsyncEnumerable<ApiResponse> RequestStreamAsync(
+      HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      string responseJson = _responses.Count > 0 ? _responses.Dequeue() : "{}";
+      await Task.Yield();
+      yield return new StreamingApiResponse(responseJson, new HttpResponseMessage());
+    }
   }
 }
 

--- a/Google.GenAI.Tests/Netstandard2_0Tests/packages.lock.json
+++ b/Google.GenAI.Tests/Netstandard2_0Tests/packages.lock.json
@@ -64,12 +64,12 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       },
       "Castle.Core": {
@@ -225,8 +225,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -256,14 +256,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -280,11 +280,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {

--- a/Google.GenAI.Tests/packages.lock.json
+++ b/Google.GenAI.Tests/packages.lock.json
@@ -209,8 +209,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -240,14 +240,14 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "google.genai": {
         "type": "Project",
         "dependencies": {
           "Google.Apis.Auth": "[1.69.0, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.3.0, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.4.0, )",
           "MimeTypes": "[2.5.2, )"
         }
       },
@@ -264,11 +264,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -279,12 +279,12 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }

--- a/Google.GenAI/GoogleGenAIChatClient.cs
+++ b/Google.GenAI/GoogleGenAIChatClient.cs
@@ -558,6 +558,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
   /// <summary>Creates <see cref="AIContent"/>s for <paramref name="parts"/> and adds them to <paramref name="contents"/>.</summary>
   private static void AddAIContentsForParts(List<Part> parts, IList<AIContent> contents)
   {
+    string? lastCodeCallId = null;
     foreach (var part in parts)
     {
       AIContent content;
@@ -593,7 +594,8 @@ internal sealed class GoogleGenAIChatClient : IChatClient
       }
       else if (part.ExecutableCode is { Code: not null } executableCode)
       {
-        content = new CodeInterpreterToolCallContent()
+        lastCodeCallId = Guid.NewGuid().ToString("N");
+        content = new CodeInterpreterToolCallContent(lastCodeCallId)
         {
           Inputs = new List<AIContent>()
           {
@@ -607,7 +609,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
       }
       else if (part.CodeExecutionResult is { Output: { } codeOutput } codeExecutionResult)
       {
-        content = new CodeInterpreterToolResultContent()
+        content = new CodeInterpreterToolResultContent(lastCodeCallId ?? Guid.NewGuid().ToString("N"))
         {
           Outputs = new List<AIContent>()
            {
@@ -616,6 +618,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
               new ErrorContent(codeOutput) { ErrorCode = codeExecutionResult.Outcome.ToString() }
            },
         };
+        lastCodeCallId = null;
       }
       else
       {
@@ -675,6 +678,41 @@ internal sealed class GoogleGenAIChatClient : IChatClient
               }
           };
         }
+      }
+
+      // Add web search grounding metadata as WebSearchToolCallContent/WebSearchToolResultContent.
+      if (candidate.GroundingMetadata is { } groundingMetadata &&
+          (groundingMetadata.WebSearchQueries is { Count: > 0 } || groundingMetadata.GroundingChunks is { Count: > 0 }))
+      {
+        string searchCallId = Guid.NewGuid().ToString("N");
+
+        responseContents.Add(new WebSearchToolCallContent(searchCallId)
+        {
+          Queries = groundingMetadata.WebSearchQueries,
+          RawRepresentation = groundingMetadata,
+        });
+
+        List<AIContent>? searchResults = null;
+        if (groundingMetadata.GroundingChunks is { } chunks)
+        {
+          foreach (var chunk in chunks)
+          {
+            if (chunk.Web is { Uri: not null } web)
+            {
+              var result = new UriContent(new Uri(web.Uri), MimeTypes.TryGetMimeType(web.Uri, out string mimeType) ? mimeType : "application/octet-stream");
+              if (web.Title is not null)
+              {
+                (result.AdditionalProperties ??= new())["title"] = web.Title;
+              }
+              (searchResults ??= new()).Add(result);
+            }
+          }
+        }
+
+        responseContents.Add(new WebSearchToolResultContent(searchCallId)
+        {
+          Results = searchResults,
+        });
       }
     }
 

--- a/Google.GenAI/GoogleGenAIExtensions.cs
+++ b/Google.GenAI/GoogleGenAIExtensions.cs
@@ -103,4 +103,30 @@ public static class GoogleGenAIExtensions
     Utilities.ThrowIfNull(models, nameof(models));
     return new GoogleGenAIEmbeddingGenerator(models, defaultModelId, defaultModelDimensions);
   }
+
+  /// <summary>
+  /// Creates an <see cref="IHostedFileClient"/> wrapper around the specified <see cref="Client"/>.
+  /// </summary>
+  /// <param name="client">The <see cref="Client"/> to wrap.</param>
+  /// <returns>An <see cref="IHostedFileClient"/> that wraps the specified client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="client"/> is <see langword="null"/>.</exception>
+  /// <remarks>The hosted file client is only supported with the Gemini Developer API, not Vertex AI.</remarks>
+  public static IHostedFileClient AsIHostedFileClient(this Client client)
+  {
+    Utilities.ThrowIfNull(client, nameof(client));
+    return new GoogleGenAIHostedFileClient(client);
+  }
+
+  /// <summary>
+  /// Creates an <see cref="IHostedFileClient"/> wrapper around the specified <see cref="Files"/>.
+  /// </summary>
+  /// <param name="files">The <see cref="Files"/> client to wrap.</param>
+  /// <returns>An <see cref="IHostedFileClient"/> that wraps the specified <see cref="Files"/> client.</returns>
+  /// <exception cref="ArgumentNullException"><paramref name="files"/> is <see langword="null"/>.</exception>
+  /// <remarks>The hosted file client is only supported with the Gemini Developer API, not Vertex AI.</remarks>
+  public static IHostedFileClient AsIHostedFileClient(this Files files)
+  {
+    Utilities.ThrowIfNull(files, nameof(files));
+    return new GoogleGenAIHostedFileClient(files);
+  }
 }

--- a/Google.GenAI/GoogleGenAIHostedFileClient.cs
+++ b/Google.GenAI/GoogleGenAIHostedFileClient.cs
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+
+using Google.Apis.Util;
+using Google.GenAI;
+using Google.GenAI.Types;
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>Provides an <see cref="IHostedFileClient"/> implementation based on <see cref="Client"/>.</summary>
+internal sealed class GoogleGenAIHostedFileClient : IHostedFileClient
+{
+  /// <summary>The wrapped <see cref="Client"/> instance (optional).</summary>
+  private readonly Client? _client;
+
+  /// <summary>The wrapped <see cref="Files"/> instance.</summary>
+  private readonly Files _files;
+
+  /// <summary>Lazily-initialized metadata describing the implementation.</summary>
+  private HostedFileClientMetadata? _metadata;
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIHostedFileClient"/> instance.</summary>
+  public GoogleGenAIHostedFileClient(Client client)
+  {
+    _client = client;
+    _files = client.Files;
+  }
+
+  /// <summary>Initializes a new <see cref="GoogleGenAIHostedFileClient"/> instance.</summary>
+  public GoogleGenAIHostedFileClient(Files files)
+  {
+    _files = files;
+  }
+
+  /// <inheritdoc />
+  public async Task<HostedFileContent> UploadAsync(
+    Stream content,
+    string? mediaType = null,
+    string? fileName = null,
+    HostedFileClientOptions? options = null,
+    CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(content, nameof(content));
+
+    UploadFileConfig? config = options?.RawRepresentationFactory?.Invoke(this) as UploadFileConfig ?? new();
+    config.MimeType ??= mediaType;
+    config.DisplayName ??= fileName;
+
+    // The Gemini upload API requires an accurate size. If the stream isn't seekable,
+    // buffer it so we can determine the length.
+    Stream uploadStream = content;
+    long size;
+    if (content.CanSeek)
+    {
+      size = content.Length - content.Position;
+    }
+    else
+    {
+      var buffer = new MemoryStream();
+      await content.CopyToAsync(buffer
+#if !NETSTANDARD2_0
+        , cancellationToken
+#endif
+        ).ConfigureAwait(false);
+      buffer.Position = 0;
+      size = buffer.Length;
+      uploadStream = buffer;
+    }
+
+    Google.GenAI.Types.File file = await _files.UploadAsync(uploadStream, size, fileName, mediaType, config, cancellationToken).ConfigureAwait(false);
+    return ToHostedFileContent(file);
+  }
+
+  /// <inheritdoc />
+  public async Task<HostedFileDownloadStream> DownloadAsync(
+    string fileId,
+    HostedFileClientOptions? options = null,
+    CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(fileId, nameof(fileId));
+
+    // Get file metadata so we can populate MediaType and FileName on the download stream.
+    Google.GenAI.Types.File fileInfo = await _files.GetAsync(fileId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    Stream stream = await _files.DownloadAsync(fileId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    return new GoogleGenAIHostedFileDownloadStream(stream, fileInfo.MimeType, fileInfo.DisplayName);
+  }
+
+  /// <inheritdoc />
+  public async Task<HostedFileContent?> GetFileInfoAsync(
+    string fileId,
+    HostedFileClientOptions? options = null,
+    CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(fileId, nameof(fileId));
+
+    Google.GenAI.Types.File file = await _files.GetAsync(fileId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    return ToHostedFileContent(file);
+  }
+
+  /// <inheritdoc />
+  public async IAsyncEnumerable<HostedFileContent> ListFilesAsync(
+    HostedFileClientOptions? options = null,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    ListFilesConfig? config = options?.RawRepresentationFactory?.Invoke(this) as ListFilesConfig;
+    if (options?.Limit is { } limit)
+    {
+      (config ??= new()).PageSize ??= limit;
+    }
+
+    var pager = await _files.ListAsync(config, cancellationToken).ConfigureAwait(false);
+
+    await foreach (var file in pager.WithCancellation(cancellationToken).ConfigureAwait(false))
+    {
+      yield return ToHostedFileContent(file);
+    }
+  }
+
+  /// <inheritdoc />
+  public async Task<bool> DeleteAsync(
+    string fileId,
+    HostedFileClientOptions? options = null,
+    CancellationToken cancellationToken = default)
+  {
+    Utilities.ThrowIfNull(fileId, nameof(fileId));
+
+    await _files.DeleteAsync(fileId, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return true;
+  }
+
+  /// <inheritdoc />
+  public object? GetService(System.Type serviceType, object? serviceKey = null)
+  {
+    Utilities.ThrowIfNull(serviceType, nameof(serviceType));
+
+    if (serviceKey is null)
+    {
+      if (serviceType == typeof(HostedFileClientMetadata))
+      {
+        return _metadata ??= new("gcp.gen_ai", new("https://generativelanguage.googleapis.com/"));
+      }
+
+      if (serviceType.IsInstanceOfType(_files))
+      {
+        return _files;
+      }
+
+      if (_client is not null && serviceType.IsInstanceOfType(_client))
+      {
+        return _client;
+      }
+
+      if (serviceType.IsInstanceOfType(this))
+      {
+        return this;
+      }
+    }
+
+    return null;
+  }
+
+  /// <inheritdoc />
+  void IDisposable.Dispose() { /* nop */ }
+
+  /// <summary>Converts a Google <see cref="Google.GenAI.Types.File"/> to a <see cref="HostedFileContent"/>.</summary>
+  private static HostedFileContent ToHostedFileContent(Google.GenAI.Types.File file)
+  {
+    HostedFileContent content = new(file.Name ?? throw new InvalidOperationException("File.Name is required"))
+    {
+      MediaType = file.MimeType,
+      Name = file.DisplayName,
+      RawRepresentation = file,
+    };
+
+    content.SizeInBytes = file.SizeBytes;
+    content.CreatedAt = file.CreateTime;
+
+    return content;
+  }
+
+  /// <summary>A <see cref="HostedFileDownloadStream"/> that wraps a <see cref="Stream"/> from the Google GenAI download API.</summary>
+  private sealed class GoogleGenAIHostedFileDownloadStream : HostedFileDownloadStream
+  {
+    private readonly Stream _inner;
+
+    public GoogleGenAIHostedFileDownloadStream(Stream inner, string? mediaType, string? fileName)
+    {
+      _inner = inner;
+      MediaType = mediaType;
+      FileName = fileName;
+    }
+
+    public override string? MediaType { get; }
+    public override string? FileName { get; }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+    public override long Position { get => _inner.Position; set => _inner.Position = value; }
+
+    public override void Flush() => _inner.Flush();
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+    public override int ReadByte() =>
+      _inner.ReadByte();
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+      _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
+      _inner.BeginRead(buffer, offset, count, callback, state);
+
+    public override int EndRead(IAsyncResult asyncResult) =>
+      _inner.EndRead(asyncResult);
+
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
+      _inner.CopyToAsync(destination, bufferSize, cancellationToken);
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+      _inner.FlushAsync(cancellationToken);
+
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing)
+      {
+        _inner.Dispose();
+      }
+      base.Dispose(disposing);
+    }
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+#if NET
+    public override void CopyTo(Stream destination, int bufferSize) =>
+      _inner.CopyTo(destination, bufferSize);
+
+    public override int Read(Span<byte> buffer) =>
+      _inner.Read(buffer);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+      _inner.ReadAsync(buffer, cancellationToken);
+#endif
+  }
+}

--- a/Google.GenAI/packages.lock.json
+++ b/Google.GenAI/packages.lock.json
@@ -15,11 +15,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -75,8 +75,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ==",
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA==",
         "dependencies": {
           "System.Buffers": "4.6.1",
           "System.Memory": "4.6.3",
@@ -113,8 +113,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw==",
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg==",
         "dependencies": {
           "System.Buffers": "4.6.1",
           "System.Memory": "4.6.3",
@@ -132,24 +132,24 @@
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "CentralTransitive",
         "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA==",
+        "resolved": "10.0.4",
+        "contentHash": "2JmoSZ1wDf1/TUyTtLTXeicXCnWxXkeStGnzRRmAw+5CBIGhg6q9ieJXu4FjeLzawSGd5PMhcropNa3lPJDaKA==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.4",
           "System.Buffers": "4.6.1",
-          "System.IO.Pipelines": "10.0.3",
+          "System.IO.Pipelines": "10.0.4",
           "System.Memory": "4.6.3",
           "System.Runtime.CompilerServices.Unsafe": "6.1.2",
-          "System.Text.Encodings.Web": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.4",
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
       }
@@ -168,11 +168,11 @@
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
-        "requested": "[10.3.0, )",
-        "resolved": "10.3.0",
-        "contentHash": "hDjDvUERvUH3HBMs2MDusOcGJBjAHOG5pJIU2x/HZEa4e1UthNKt89cwMi3B+ogJo6skki1XFjfgGN3ksnVqvQ==",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ==",
         "dependencies": {
-          "System.Text.Json": "10.0.3"
+          "System.Text.Json": "10.0.4"
         }
       },
       "MimeTypes": {
@@ -209,8 +209,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.4",
+        "contentHash": "V7+RO17s/tzCpgqyj6t5vb54HFCvrRaMEwTcKDwpoQK66DRROzSff6kqtzHyiWRj6hrQQUmW80NL4pFSNhYpYA=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -222,17 +222,17 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+        "resolved": "10.0.4",
+        "contentHash": "6g3B7jNsPRNf4luuYt1qE4R8S3JI+zMsfGWL9Idv4Mk1Z9Gh+rCagp9sG3AejPS87yBj1DjopM4i3wSz0WnEqg=="
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "1tRPRt8D/kzjGL7em1uJ3iJlvVIC3G/sZJ+ZgSvtVYLXGGO26Clkqy2b5uts/pyR706Yw8/xA7exeI2PI50dpw==",
         "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
+          "System.IO.Pipelines": "10.0.4",
+          "System.Text.Encodings.Web": "10.0.4"
         }
       }
     }


### PR DESCRIPTION
Update `Microsoft.Extensions.AI.Abstractions` from 10.3.0 to **10.4.0** and `System.Text.Json` from 10.0.3 to 10.0.4.

## Breaking changes addressed

- **`CodeInterpreterToolCallContent` / `CodeInterpreterToolResultContent`**: These types now inherit from `ToolCallContent` / `ToolResultContent` instead of `AIContent`, requiring a `callId` constructor argument. Added a `lastCodeCallId` tracking variable so that each `ExecutableCode` part generates a GUID that is reused by the corresponding `CodeExecutionResult`.

## New surface area adopted

### `WebSearchToolCallContent` / `WebSearchToolResultContent`
Google's `GroundingMetadata` on candidates is now mapped to these new MEAI types:
- `WebSearchToolCallContent.Queries` ← `GroundingMetadata.WebSearchQueries`
- `WebSearchToolResultContent.Results` ← `GroundingMetadata.GroundingChunks[].Web` (as `UriContent` with title)

### `IHostedFileClient`
Implemented `GoogleGenAIHostedFileClient` wrapping the Google Files API (Gemini Developer API only):
| MEAI method | Google Files API |
|---|---|
| `UploadAsync` | `Files.UploadAsync` (buffers non-seekable streams for accurate size) |
| `DownloadAsync` | `Files.GetAsync` (metadata) + `Files.DownloadAsync` (stream) |
| `GetFileInfoAsync` | `Files.GetAsync` |
| `ListFilesAsync` | `Files.ListAsync` (paged → `IAsyncEnumerable`) |
| `DeleteAsync` | `Files.DeleteAsync` |

Extension methods `AsIHostedFileClient()` added on both `Client` and `Files`.

## Tests
- Added `IChatClient_ResponseWithWebSearchGrounding` unit test
- Added 20 unit tests for the hosted file client (property mapping, list enumeration, download stream metadata, null guards, `GetService` behavior, dispose)
