### PR TITLE
feat: Allow api key + proj/location for enterprise mode

### DIFF
--- a/Google.GenAI.Tests/ClientTest.cs
+++ b/Google.GenAI.Tests/ClientTest.cs
@@ -357,11 +357,13 @@ namespace Google.GenAI.Tests {
     }
 
     [TestMethod]
-    public void Constructor_Error_ApiKeySet_VertexAITrue_Param() {
-      var ex = Assert.ThrowsException<ArgumentException>(
-          () => new Client(vertexAI: true, apiKey: "key", project: "project", location: "location"));
-      Assert.AreEqual("Project/location and API key are mutually exclusive in the client initializer.",
-                      ex.Message);
+    public void Constructor_ApiKeySet_VertexAITrue_Param() {
+      var client = new Client(vertexAI: true, apiKey: "key", project: "project", location: "location");
+      Assert.IsTrue(client._apiClient.VertexAI);
+      Assert.AreEqual("key", client._apiClient.ApiKey);
+      Assert.AreEqual("project", client._apiClient.Project);
+      Assert.AreEqual("location", client._apiClient.Location);
+      Assert.IsNull(client._apiClient.Credentials);
     }
 
     [TestMethod]

--- a/Google.GenAI.Tests/HttpApiClientTest.cs
+++ b/Google.GenAI.Tests/HttpApiClientTest.cs
@@ -360,6 +360,15 @@ namespace Google.GenAI.Tests {
     }
 
     [TestMethod]
+    public async System.Threading.Tasks.Task CreateHttpRequestAsync_Vertex_ApiKeyWithProjectLocation_PrependsPath() {
+      var client = new HttpApiClient(vertexAI: true, apiKey: "my-key", project: "my-project", location: "us-central1");
+
+      var request = await InvokeCreateHttpRequestAsync(client, System.Net.Http.HttpMethod.Post, "some/path", "{}", null);
+
+      Assert.AreEqual("https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project/locations/us-central1/some/path", request.RequestUri!.ToString());
+    }
+
+    [TestMethod]
     public async Task CreateHttpRequestAsync_RewritesAbsoluteUrlWithBaseUrl() {
         var customHttpOptions = new Types.HttpOptions { BaseUrl = "https://my-proxy.company.com" };
         var client = new HttpApiClient(apiKey: TestApiKey, httpOptions: customHttpOptions);

--- a/Google.GenAI/ApiClient.cs
+++ b/Google.GenAI/ApiClient.cs
@@ -102,7 +102,7 @@ namespace Google.GenAI
             "base_url must be set when base_url_resource_scope is set.");
       }
 
-      if ((project != null || location != null) && apiKey != null)
+      if ((project != null || location != null) && apiKey != null && !this.VertexAI)
       {
         throw new ArgumentException(
             "Project/location and API key are mutually exclusive in the client initializer.");
@@ -115,22 +115,27 @@ namespace Google.GenAI
 
       if (this.VertexAI)
       {
-        if (credentials != null && !string.IsNullOrEmpty(envApiKey))
+        bool explicitApiKeyAndProject = apiKey != null && (project != null || location != null);
+
+        if (!explicitApiKeyAndProject)
         {
-          this.ApiKey = null;
-        }
-        else if ((!string.IsNullOrEmpty(envLocation) || !string.IsNullOrEmpty(envProject)) && !string.IsNullOrEmpty(apiKey))
-        {
-          this.Project = null;
-          this.Location = null;
-        }
-        else if ((!string.IsNullOrEmpty(project) || !string.IsNullOrEmpty(location)) && !string.IsNullOrEmpty(envApiKey))
-        {
-          this.ApiKey = null;
-        }
-        else if ((!string.IsNullOrEmpty(envLocation) || !string.IsNullOrEmpty(envProject)) && !string.IsNullOrEmpty(envApiKey))
-        {
-          this.ApiKey = null;
+          if (credentials != null && !string.IsNullOrEmpty(envApiKey))
+          {
+            this.ApiKey = null;
+          }
+          else if ((!string.IsNullOrEmpty(envLocation) || !string.IsNullOrEmpty(envProject)) && !string.IsNullOrEmpty(apiKey))
+          {
+            this.Project = null;
+            this.Location = null;
+          }
+          else if ((!string.IsNullOrEmpty(project) || !string.IsNullOrEmpty(location)) && !string.IsNullOrEmpty(envApiKey))
+          {
+            this.ApiKey = null;
+          }
+          else if ((!string.IsNullOrEmpty(envLocation) || !string.IsNullOrEmpty(envProject)) && !string.IsNullOrEmpty(envApiKey))
+          {
+            this.ApiKey = null;
+          }
         }
 
         if (string.IsNullOrEmpty(this.Location) && string.IsNullOrEmpty(this.ApiKey))
@@ -156,7 +161,7 @@ namespace Google.GenAI
           this.ApiKey = null;
         }
 
-        if (!string.IsNullOrEmpty(this.Project) && !string.IsNullOrEmpty(this.Location))
+        if (!string.IsNullOrEmpty(this.Project) && !string.IsNullOrEmpty(this.Location) && string.IsNullOrEmpty(this.ApiKey))
         {
           this.Credentials ??= GetDefaultCredentials();
         }

--- a/Google.GenAI/HttpApiClient.cs
+++ b/Google.GenAI/HttpApiClient.cs
@@ -185,7 +185,7 @@ namespace Google.GenAI
     private bool ShouldPrependVertexProjectPath(Types.HttpOptions mergedHttpOptions)
     {
       if (!this.VertexAI) return false;
-      if (!string.IsNullOrEmpty(this.ApiKey)) return false;
+      if (!string.IsNullOrEmpty(this.ApiKey) && (string.IsNullOrEmpty(this.Project) || string.IsNullOrEmpty(this.Location))) return false;
       if (string.IsNullOrEmpty(this.Project) && string.IsNullOrEmpty(this.Location)) return false;
       if (mergedHttpOptions.BaseUrlResourceScope == Types.ResourceScope.Collection && !string.IsNullOrEmpty(mergedHttpOptions.BaseUrl)) return false;
       return true;


### PR DESCRIPTION
## Summary

Allow passing `apiKey` together with `project` and `location` when `vertexAI: true`. This enables Vertex AI Express Mode on project-scoped endpoints — required for services like Veo and Imagen that need a project path in the URL while authenticating with an API key.

Fixes #305

## Changes

**`ApiClient.cs`** (3 changes):
- Gate the mutually-exclusive `ArgumentException` on `!this.VertexAI` so it only applies to non-Vertex usage
- Skip conflict resolution when both `apiKey` and `project`/`location` are explicitly provided as constructor params (`explicitApiKeyAndProject` guard)
- Skip `GetDefaultCredentials()` when `ApiKey` is set — API key auth doesn't need ADC

**`HttpApiClient.cs`** (1 change):
- Fix `ShouldPrependVertexProjectPath` to allow path prepend when `ApiKey` is present alongside `Project`/`Location`

**Tests**:
- Updated `Constructor_Error_ApiKeySet_VertexAITrue_Param` to expect success instead of a throw
- Added `CreateHttpRequestAsync_Vertex_ApiKeyWithProjectLocation_PrependsPath` to verify correct URL construction

## Behavior

```csharp
// Before: throws ArgumentException
// After: works — constructs project-scoped Vertex AI URLs with API key auth
var client = new Client(vertexAI: true, apiKey: "key", project: "my-project", location: "us-central1");
```

The SDK already handles this correctly in `SetHeadersAsync` — when `ApiKey` is set, it adds `x-goog-api-key` and skips the Bearer token. No changes needed there.

Non-Vertex usage (`vertexAI: false`) still throws if `project`/`location` are combined with `apiKey`, preserving existing behavior.
