### PR TITLE
feat: Add Stale Bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+# This workflow warns and then closes issues that have had no activity for a specified amount of time.
+name: Mark and close stale issues
+
+on:
+  schedule:
+  # Scheduled to run at 1:30 UTC everyday
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 7
+        days-before-issue-close: 2
+        stale-issue-label: "status:stale"
+        close-issue-reason: not_planned
+        any-of-labels: "status:awaiting user response"
+        remove-stale-when-updated: true
+        labels-to-remove-when-unstale: 'status:awaiting user response,status:stale'
+        stale-issue-message: >
+          This issue has been marked as stale because it has been open for 7 days with no activity. It will be closed in 2 days if no further activity occurs.
+        close-issue-message: >
+          This issue was closed because it has been inactive for 9 days.
+          Please post a new issue if you need further assistance. Thanks!
+        # Label that can be assigned to issues to exclude them from being marked as stale
+        exempt-issue-labels: 'override-stale'


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically manage stale issues and pull requests using the actions/stale action.

**Purpose:**

To improve repository hygiene and help maintainers focus on active items by:
  Automatically identifying issues and pull requests that have been inactive for an extended period.
  Notifying participants that an item is stale.
  Closing items that remain inactive after a grace period.

**Implementation Details:**

  A new workflow configuration file is added at .github/workflows/stale.yml.
  The workflow is scheduled to run daily at 01:30 UTC.
  It uses the standard actions/stale@v9.

**Key Configuration:**

  **Stale After:** Items with no activity for 7 days will be marked as stale.
  **Close After:** Stale items will be closed if there's no further activity for 2 days after being marked.
  **Labels:** The label stale will be applied to stale issues and PRs.
  **Messages:** Custom messages are configured to inform users why an item is marked stale and when it will be closed.

This automation aims to reduce the burden of manually tracking and closing abandoned issues and pull requests.