### PR TITLE
fix: Propagate CancellationToken in GoogleGenAIChatClient.GetResponseAsync

### DIFF
--- a/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
+++ b/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
@@ -5445,6 +5445,32 @@ public class GoogleGenAIExtensionsTest
   }
 
   [TestMethod]
+  public async Task IChatClient_GetResponseAsync_PropagatesCancellationToken()
+  {
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+
+    IChatClient client = CreateChatClient("", "");
+
+    await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+      () => client.GetResponseAsync("Hello", cancellationToken: cts.Token));
+  }
+
+  [TestMethod]
+  public async Task IChatClient_GetStreamingResponseAsync_PropagatesCancellationToken()
+  {
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+
+    IChatClient client = CreateChatClient("", "");
+
+    await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+    {
+      await foreach (var _ in client.GetStreamingResponseAsync("Hello", cancellationToken: cts.Token)) { }
+    });
+  }
+
+  [TestMethod]
   public async Task IImageGeneration_BasicRequest()
   {
     IImageGenerator imageGenerator = CreateImageGenerator("""
@@ -5614,6 +5640,7 @@ public class GoogleGenAIExtensionsTest
     public override async Task<ApiResponse> RequestAsync(
       HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, CancellationToken cancellationToken = default)
     {
+      cancellationToken.ThrowIfCancellationRequested();
       string responseJson = _actualResponse;
 
       if (_makeRealRequest)
@@ -5635,6 +5662,7 @@ public class GoogleGenAIExtensionsTest
     public override async IAsyncEnumerable<ApiResponse> RequestStreamAsync(
       HttpMethod httpMethod, string path, string requestJson, HttpOptions? requestHttpOptions, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+      cancellationToken.ThrowIfCancellationRequested();
       string responseData = _actualResponse;
 
       if (_makeRealRequest)

--- a/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
+++ b/Google.GenAI.Tests/GoogleGenAIExtensionsTest.cs
@@ -5471,6 +5471,30 @@ public class GoogleGenAIExtensionsTest
   }
 
   [TestMethod]
+  public async Task IEmbeddingGenerator_GenerateAsync_PropagatesCancellationToken()
+  {
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+
+    var embeddingGenerator = CreateEmbeddingGenerator("", "");
+
+    await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+      () => embeddingGenerator.GenerateAsync(["Hello"], cancellationToken: cts.Token));
+  }
+
+  [TestMethod]
+  public async Task IImageGenerator_GenerateAsync_PropagatesCancellationToken()
+  {
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+
+    var imageGenerator = CreateImageGenerator("", "");
+
+    await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+      () => imageGenerator.GenerateAsync(new ImageGenerationRequest { Prompt = "A cat" }, cancellationToken: cts.Token));
+  }
+
+  [TestMethod]
   public async Task IImageGeneration_BasicRequest()
   {
     IImageGenerator imageGenerator = CreateImageGenerator("""

--- a/Google.GenAI/.editorconfig
+++ b/Google.GenAI/.editorconfig
@@ -41,6 +41,7 @@ dotnet_diagnostic.IDE0017.severity = none
 dotnet_diagnostic.IDE0028.severity = none
 dotnet_diagnostic.CS8603.severity = none
 dotnet_diagnostic.CS8424.severity = none
+dotnet_diagnostic.CA2016.severity = warning
 dotnet_diagnostic.CS0108.severity = none
 
 [*.csproj]

--- a/Google.GenAI/Google.GenAI.csproj
+++ b/Google.GenAI/Google.GenAI.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WarningsAsErrors>$(WarningsAsErrors);CS1570</WarningsAsErrors><NoWarn>$(NoWarn);CS1591</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1570;CA2016</WarningsAsErrors><NoWarn>$(NoWarn);CS1591</NoWarn>
     <WarningsNotAsErrors>IDE0005</WarningsNotAsErrors>
     <NoWarn>$(NoWarn);MEAI001</NoWarn>
   </PropertyGroup>

--- a/Google.GenAI/GoogleGenAIChatClient.cs
+++ b/Google.GenAI/GoogleGenAIChatClient.cs
@@ -103,7 +103,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
 
     // Send it, and process the results.
     GenerateContentResponseUsageMetadata? lastUsageMetadata = null;
-    await foreach (GenerateContentResponse generateResult in _models.GenerateContentStreamAsync(modelId!, contents, config).WithCancellation(cancellationToken).ConfigureAwait(false))
+    await foreach (GenerateContentResponse generateResult in _models.GenerateContentStreamAsync(modelId!, contents, config, cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false))
     {
       // Create a response update for each result in the stream.
       ChatResponseUpdate responseUpdate = new(ChatRole.Assistant, new List<AIContent>())

--- a/Google.GenAI/GoogleGenAIChatClient.cs
+++ b/Google.GenAI/GoogleGenAIChatClient.cs
@@ -69,7 +69,7 @@ internal sealed class GoogleGenAIChatClient : IChatClient
     (string? modelId, List<Content> contents, GenerateContentConfig config) = CreateRequest(messages, options);
 
     // Send it.
-    GenerateContentResponse generateResult = await _models.GenerateContentAsync(modelId!, contents, config).ConfigureAwait(false);
+    GenerateContentResponse generateResult = await _models.GenerateContentAsync(modelId!, contents, config, cancellationToken).ConfigureAwait(false);
 
     // Create the response.
     ChatResponse chatResponse = new(new ChatMessage(ChatRole.Assistant, new List<AIContent>()) { MessageId = generateResult.ResponseId })

--- a/Google.GenAI/GoogleGenAIEmbeddingGenerator.cs
+++ b/Google.GenAI/GoogleGenAIEmbeddingGenerator.cs
@@ -74,7 +74,8 @@ internal sealed class GoogleGenAIEmbeddingGenerator : IEmbeddingGenerator<string
     EmbedContentResponse response = await _models.EmbedContentAsync(
       modelId,
       values.Select(value => new Content() { Parts = new List<Part>() { new() { Text = value } } }).ToList(),
-      config).ConfigureAwait(false);
+      config,
+      cancellationToken).ConfigureAwait(false);
 
     if (response.Embeddings is not null)
     {

--- a/Google.GenAI/GoogleGenAIImageGenerator.cs
+++ b/Google.GenAI/GoogleGenAIImageGenerator.cs
@@ -65,7 +65,7 @@ internal sealed class GoogleGenAIImageGenerator : IImageGenerator
     config.OutputMimeType ??= options?.MediaType;
     config.AspectRatio ??= options?.ImageSize is { } imageSize && imageSize.Width > 0 && imageSize.Height > 0 ? GetClosestRatio(imageSize) : null;
 
-    var gir = await _models.GenerateImagesAsync(modelId, prompt, config).ConfigureAwait(false);
+    var gir = await _models.GenerateImagesAsync(modelId, prompt, config, cancellationToken).ConfigureAwait(false);
 
     ImageGenerationResponse response = new()
     {


### PR DESCRIPTION
Pass the `cancellationToken` to Models.GenerateContentAsync in the non-streaming IChatClient adapter path. The streaming counterpart already propagated it via WithCancellation.

Add cancellation-propagation tests for both GetResponseAsync and GetStreamingResponseAsync.

Fixes #328