### PR TITLE
feat: expose websocket close status in AsyncSession

### DIFF
--- a/Google.GenAI/Live.cs
+++ b/Google.GenAI/Live.cs
@@ -215,6 +215,9 @@ namespace Google.GenAI
     private readonly ApiClient _apiClient;
     private int _isDisposed = 0; // 0 = false, 1 = true. Used with Interlocked.
 
+    public WebSocketCloseStatus? CloseStatus => _webSocket.CloseStatus;
+    public string? CloseStatusDescription => _webSocket.CloseStatusDescription;
+
     public AsyncSession(WebSocket webSocket, ApiClient apiClient)
     {
       _webSocket = webSocket;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

Currently in the `main` branch, when a Gemini Live API session is disconnected, client applications cannot determine the exact reason for the disconnection. 

The internal `WebSocket` instance (`_webSocket`) in the `AsyncSession` class is private, meaning that `CloseStatus` and `CloseStatusDescription` are not accessible from the outside. 

This prevents developers from implementing appropriate error handling or reconnection logic based on specific close codes.

**Describe the solution you'd like**

Expose the `CloseStatus` and `CloseStatusDescription` of the underlying `WebSocket` via read-only properties on the `AsyncSession` class:

```csharp
public WebSocketCloseStatus? CloseStatus => _webSocket.CloseStatus;
public string? CloseStatusDescription => _webSocket.CloseStatusDescription;
```